### PR TITLE
Add response header handler: `content_length`

### DIFF
--- a/moona/http/__init__.py
+++ b/moona/http/__init__.py
@@ -31,6 +31,7 @@ from .request_method import (
 from .request_route import route, route_ci, subroute, subroute_ci
 from .response_body import json, negotiate, raw, set_json, set_raw, set_text, text
 from .response_headers import (
+    content_length,
     content_type,
     content_type_application_json,
     content_type_text_plain,

--- a/moona/http/response_headers.py
+++ b/moona/http/response_headers.py
@@ -1,7 +1,7 @@
 from pymon import Future, Pipe
 
 from moona.http.context import HTTPContext, set_response_header
-from moona.http.handlers import HTTPFunc, handler2
+from moona.http.handlers import HTTPFunc, HTTPHandler, handler2
 
 
 @handler2
@@ -65,3 +65,12 @@ def content_type_text_plain(
         Future[HTTPContext | None]: result.
     """
     return content_type("text/plain")(nxt, ctx)
+
+
+def content_length(value: int) -> HTTPHandler:
+    """`HTTPHandler` that sets "Content-Length` response header.
+
+    Args:
+        value (int): of header
+    """
+    return header("content-length", str(value))

--- a/tests/http/test_response_headers.py
+++ b/tests/http/test_response_headers.py
@@ -2,6 +2,7 @@ import pytest
 
 from moona.http import HTTPContext, end
 from moona.http.response_headers import (
+    content_length,
     content_type,
     content_type_application_json,
     content_type_text_plain,
@@ -47,3 +48,17 @@ async def test_content_type_application_json(ctx: HTTPContext):
 async def test_content_type_text_plain(ctx: HTTPContext):
     _ctx = await content_type_text_plain(end, ctx)
     assert _ctx.response_headers[b"content-type"] == b"text/plain"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "s_value, b_value",
+    [
+        (0, b"0"),
+        (12, b"12"),
+        (2355, b"2355"),
+    ],
+)
+async def test_content_length(ctx: HTTPContext, s_value, b_value):
+    _ctx = await content_length(s_value)(end, ctx)
+    assert _ctx.response_headers[b"content-length"] == b_value


### PR DESCRIPTION
- Update dependencies
- Rework `Future` (#43)
- Fix tests for `Future` monad (#43)
- Fix `body` handler (#43)
- Fix `handlers.core` (#43)
- Fix `handlers.error` (#43)
- Add `Pipe` monad (#42)
- Remove aliases for operators (#42)
- Remove annotation and code complexity flake8 (#42)
- Add `Chain` composer  (#42)
- Rename `Chain` -> `Func` (#42)
- Rename `abind`/`sbind` to `then` and `then_future` (#42)
- Add imports for pipe and func to monad root (#42)
- Fix docstrings for `Future` (#42)
- Add TODOs to `mona.core` (#42)
- Rename `Future.create` -> `Future.from_value` (#42)
- Add `FutureResult` (#42)
- Add `FutureMaybe` monad (#42)
- Add combaitiblity funcs for `Pipe` (#42)
- Add `Maybe` and `Result` compatibility for `Future` (#42)
- Rename some `Pipe` methods (#42)
- Add `Future` compatiblity to `Result` (#42)
- Add `Maybe` compatibility with `Future` (#42)
- Fix docstrings for `Func`/`FutureFunc` (#42)
- Add `Future.returns` decorator (#42)
- Remove `mona.monads.core` (#42)
- Add improvements to `FutureMaybe` monad (#42)
- Fix docstring in `Maybe` (#42)
- Add additinal functinality for `FutureResult` (#42)
- Fix `mona.monads.core` deletion consequences (#42)
- Add `FutureMaybe/Result` imports to `mona.monads` (#42)
- Improve ASIG related code (#42)
- Add status http handler and rename `Pipe` to `Pipeline` (#42)
- Add method http handlers (#42)
- Fix handler decorator for method and status handlers (#42)
- Rename `Future.identity` -> `Future.this` (#42)
- Add http event handlers (#42)
- Add util function to maybe monad (#42)
- Add body http handlers  (#42)
- Add lifespan handling (#42)
- Add error handling for http (#42)
- Add `pymon` to replace currntly existing monads (#42)
- Remove monads and old handlers for http (#42)
- Update deps (#42)
- Update `pymon` to v0.0.3 (#42)
- Bring up `moona` (#42)
- Fix `mkdocs.yml` name (#42)
- Fix title in `README.md` (#42)
- Add better examples and make minor fixes (#42)
- Complete http.context (#42)
- Remove monad examples (#42)
- Complete `moona.http.events` (#42)
- Add request headers handlers (#42)
- Remove old code (#42)
- Add request route handlers (#42)
- Add response status handlers (#42)
- Add response headers handlers (#42)
- Add request method handlers (#42)
- Add better imports to mona root (#42)
- Add response body handlers (#42)
- Add converter fot sync HTTPFunc to Handler (#42)
- Delete old body handlers (#42)
- Add response body handlers (#42)
- Add `func_handler_sync` for `LifespanFunc` (#42)
- Convert method handlers to functions (#42)
- Add `negotiate` handler for response body (#42)
- Imporove imports for `http`  (#42)
- Improve status code handlers (#42)
- Improve asgi create function (#42)
- Improve hello world example (#42)
- Improve calca example (#42)
- Fix Lifespan handlers (#42)
- Improve lifespan example (#42)
- Fix linter problems with benchmarks readme (#42)
- Improve `README.md` (#42)
- Delete tests (#42)
- Add pydantic example with negotiate (#42)
- Fix conftest (#42)
- Add tests for header handler (#42)
- Add tests for `content_type` handler (#42)
- Add tests for `application_json` and `text_plain` response headers handlers (#42)
- Add tests for response status handlers (#42)
- Add tests for response body setter (#42)
- Fix logic of `receive` handler (#42)
- Add tests for request body binding handlers (#42)
- Add tests for request headers handlers (#42)
- Add tests for request method handlers (#42)
- Add tests for request route handlers (#42)
- Add response header handler `content_length` (#26)
- Add tests for `content_length` response header handler (#26)

Closes #

**Change Notes**

- ♻️ Redesign or reimplementation
- ✨ New feature
- 🪲 Bugfix
