### PR TITLE
Add response header handler `content_length`

### DIFF
--- a/moona/http/__init__.py
+++ b/moona/http/__init__.py
@@ -31,6 +31,7 @@ from .request_method import (
 from .request_route import route, route_ci, subroute, subroute_ci
 from .response_body import json, negotiate, raw, set_json, set_raw, set_text, text
 from .response_headers import (
+    content_length,
     content_type,
     content_type_application_json,
     content_type_text_plain,

--- a/moona/http/response_headers.py
+++ b/moona/http/response_headers.py
@@ -1,7 +1,7 @@
 from pymon import Future, Pipe
 
 from moona.http.context import HTTPContext, set_response_header
-from moona.http.handlers import HTTPFunc, handler2
+from moona.http.handlers import HTTPFunc, HTTPHandler, handler2
 
 
 @handler2
@@ -65,3 +65,12 @@ def content_type_text_plain(
         Future[HTTPContext | None]: result.
     """
     return content_type("text/plain")(nxt, ctx)
+
+
+def content_length(value: int) -> HTTPHandler:
+    """`HTTPHandler` that sets "Content-Length` response header.
+
+    Args:
+        value (int): of header
+    """
+    return header("content-length", str(value))

--- a/tests/http/test_response_headers.py
+++ b/tests/http/test_response_headers.py
@@ -2,6 +2,7 @@ import pytest
 
 from moona.http import HTTPContext, end
 from moona.http.response_headers import (
+    content_length,
     content_type,
     content_type_application_json,
     content_type_text_plain,
@@ -47,3 +48,17 @@ async def test_content_type_application_json(ctx: HTTPContext):
 async def test_content_type_text_plain(ctx: HTTPContext):
     _ctx = await content_type_text_plain(end, ctx)
     assert _ctx.response_headers[b"content-type"] == b"text/plain"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "s_value, b_value",
+    [
+        (0, b"0"),
+        (12, b"12"),
+        (2355, b"2355"),
+    ],
+)
+async def test_content_length(ctx: HTTPContext, s_value, b_value):
+    _ctx = await content_length(s_value)(end, ctx)
+    assert _ctx.response_headers[b"content-length"] == b_value


### PR DESCRIPTION
- Add response header handler `content_length` (#26)
- Add tests for `content_length` response header handler (#26)

Closes #26 
