### PR TITLE
Move from `pymon` to `fundom` (v0.1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Before we wen't too far let's sum up 2 problems of try-except approach:
 Another good example of infinite checks - `None` value. Often we do something
 only if some other function previously returned some actual result.
 
-`moona` uses monads from [`pymon`](https://github.com/katunilya/pymon) (under development).
+`moona` uses monads from [`fundom`](https://github.com/katunilya/fundom) (under development).
 
 ### Be declarative means you named your child good
 
@@ -136,7 +136,7 @@ Currently `moona` supports to kinds of ASGI scope - "http" and "lifespan".
 ### HTTP Handlers
 
 HTTPHandler is a function with interface `(nxt: HTTPFunc, ctx: HTTPContext) ->
-Future[HTTPContext | None]`
+future[HTTPContext | None]`
 
 In `moona` `HTTPHandler` is actually callable class. This is required for
 providing `>>` syntax for composing multiple `HTTPHandler`s.

--- a/docs/README.md
+++ b/docs/README.md
@@ -122,7 +122,7 @@ Before we wen't too far let's sum up 2 problems of try-except approach:
 Another good example of infinite checks - `None` value. Often we do something
 only if some other function previously returned some actual result.
 
-`moona` uses monads from [`pymon`](https://github.com/katunilya/pymon) (under development).
+`moona` uses monads from [`fundom`](https://github.com/katunilya/fundom) (under development).
 
 ### Be declarative means you named your child good
 
@@ -153,7 +153,7 @@ Currently `moona` supports to kinds of ASGI scope - "http" and "lifespan".
 ### HTTP Handlers
 
 HTTPHandler is a function with interface `(nxt: HTTPFunc, ctx: HTTPContext) ->
-Future[HTTPContext | None]`
+future[HTTPContext | None]`
 
 In `moona` `HTTPHandler` is actually callable class. This is required for
 providing `>>` syntax for composing multiple `HTTPHandler`s.

--- a/docs/moona/asgi.md
+++ b/docs/moona/asgi.md
@@ -20,7 +20,7 @@ def create(
 Constructs ASGI Server function from passed handler.
 
 Supports 2 types of request scopes: "http" and "lifetime". For "http" scope
-`HTTPContext` is created and used as an argument for the `handler` (via `Future`).
+`HTTPContext` is created and used as an argument for the `handler` (via `future`).
 For "lifetime" `LifetimeContext` is created and also used as argument for `handler`.
 
 #### Notes

--- a/docs/moona/http/context.md
+++ b/docs/moona/http/context.md
@@ -314,8 +314,8 @@ Returns `HTTPContext.started`.
 [[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L82)
 
 ```python
-@hof_2
-def send_message(msg: Message, ctx: HTTPContext) -> Future[HTTPContext]:
+@hof1
+def send_message(msg: Message, ctx: HTTPContext) -> future[HTTPContext]:
 ```
 
 Sends message from [HTTPContext](#httpcontext) to client.
@@ -339,7 +339,7 @@ Sends message from [HTTPContext](#httpcontext) to client.
 [[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L151)
 
 ```python
-@hof_2
+@hof1
 def set_closed(value: bool, ctx: HTTPContext) -> HTTPContext:
 ```
 
@@ -354,7 +354,7 @@ Sync [HTTPContext](#httpcontext) that sets `closed` to `value`.
 [[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L137)
 
 ```python
-@hof_2
+@hof1
 def set_received(value: bool, ctx: HTTPContext) -> HTTPContext:
 ```
 
@@ -369,7 +369,7 @@ Sync [HTTPContext](#httpcontext) that sets `received` to `value`.
 [[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L96)
 
 ```python
-@hof_2
+@hof1
 def set_response_body(data: bytes, ctx: HTTPContext) -> HTTPContext:
 ```
 
@@ -391,7 +391,7 @@ Response body is some byte string so default `HTTPFunc` accepts `bytes`.
 [[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L122)
 
 ```python
-@hof_3
+@hof2
 def set_response_header(
     name: str,
     value: str,
@@ -416,7 +416,7 @@ Set `value` for response header `name`.
 [[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L110)
 
 ```python
-@hof_2
+@hof1
 def set_response_status(code: int, ctx: HTTPContext) -> HTTPContext:
 ```
 
@@ -436,7 +436,7 @@ Set response status code.
 [[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L144)
 
 ```python
-@hof_2
+@hof1
 def set_started(value: bool, ctx: HTTPContext) -> HTTPContext:
 ```
 

--- a/docs/moona/http/context.md
+++ b/docs/moona/http/context.md
@@ -59,7 +59,7 @@ https://asgi.readthedocs.io/en/latest/specs/www.html#
 
 ## get_asgi_spec_version
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L196)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L198)
 
 ```python
 def get_asgi_spec_version(ctx: HTTPContext):
@@ -73,7 +73,7 @@ Returns `HTTPContext.asgi_spec_version`.
 
 ## get_asgi_version
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L191)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L193)
 
 ```python
 def get_asgi_version(ctx: HTTPContext):
@@ -87,7 +87,7 @@ Returns `HTTPContext.asgi_version`.
 
 ## get_client
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L211)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L213)
 
 ```python
 def get_client(ctx: HTTPContext):
@@ -101,7 +101,7 @@ Returns `HTTPContext.client`.
 
 ## get_closed
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L246)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L248)
 
 ```python
 def get_closed(ctx: HTTPContext):
@@ -115,7 +115,7 @@ Returns `HTTPContext.closed`.
 
 ## get_http_version
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L201)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L203)
 
 ```python
 def get_http_version(ctx: HTTPContext):
@@ -129,7 +129,7 @@ Returns `HTTPContext.http_version`.
 
 ## get_received
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L236)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L238)
 
 ```python
 def get_received(ctx: HTTPContext):
@@ -143,7 +143,7 @@ Returns `HTTPContext.received`.
 
 ## get_request_body
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L181)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L183)
 
 ```python
 def get_request_body(ctx: HTTPContext):
@@ -157,7 +157,7 @@ Returns `HTTPContext.request_body`.
 
 ## get_request_headers
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L176)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L178)
 
 ```python
 def get_request_headers(ctx: HTTPContext):
@@ -171,7 +171,7 @@ Returns `HTTPContext.request_headers`.
 
 ## get_request_method
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L161)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L163)
 
 ```python
 def get_request_method(ctx: HTTPContext):
@@ -185,7 +185,7 @@ Returns `HTTPContext.request_method`.
 
 ## get_request_path
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L166)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L168)
 
 ```python
 def get_request_path(ctx: HTTPContext):
@@ -199,7 +199,7 @@ Returns `HTTPContext.request_path`.
 
 ## get_request_query_string
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L171)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L173)
 
 ```python
 def get_request_query_string(ctx: HTTPContext):
@@ -213,7 +213,7 @@ Returns `HTTPContext.request_query_string`.
 
 ## get_response_body
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L221)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L223)
 
 ```python
 def get_response_body(ctx: HTTPContext):
@@ -227,7 +227,7 @@ Returns `HTTPContext.response_body`.
 
 ## get_response_headers
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L226)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L228)
 
 ```python
 def get_response_headers(ctx: HTTPContext):
@@ -241,7 +241,7 @@ Returns `HTTPContext.response_headers`.
 
 ## get_response_status
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L231)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L233)
 
 ```python
 def get_response_status(ctx: HTTPContext):
@@ -255,7 +255,7 @@ Returns `HTTPContext.response_status`.
 
 ## get_scheme
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L206)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L208)
 
 ```python
 def get_scheme(ctx: HTTPContext):
@@ -269,7 +269,7 @@ Returns `HTTPContext.scheme`.
 
 ## get_scope_type
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L186)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L188)
 
 ```python
 def get_scope_type(ctx: HTTPContext):
@@ -283,7 +283,7 @@ Returns `HTTPContext.scope_type`.
 
 ## get_server
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L216)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L218)
 
 ```python
 def get_server(ctx: HTTPContext):
@@ -297,7 +297,7 @@ Returns `HTTPContext.server`.
 
 ## get_started
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L241)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L243)
 
 ```python
 def get_started(ctx: HTTPContext):
@@ -315,7 +315,8 @@ Returns `HTTPContext.started`.
 
 ```python
 @hof1
-def send_message(msg: Message, ctx: HTTPContext) -> future[HTTPContext]:
+@future.returns
+async def send_message(msg: Message, ctx: HTTPContext) -> HTTPContext:
 ```
 
 Sends message from [HTTPContext](#httpcontext) to client.
@@ -336,7 +337,7 @@ Sends message from [HTTPContext](#httpcontext) to client.
 
 ## set_closed
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L151)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L153)
 
 ```python
 @hof1
@@ -351,7 +352,7 @@ Sync [HTTPContext](#httpcontext) that sets `closed` to `value`.
 
 ## set_received
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L137)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L139)
 
 ```python
 @hof1
@@ -366,7 +367,7 @@ Sync [HTTPContext](#httpcontext) that sets `received` to `value`.
 
 ## set_response_body
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L96)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L98)
 
 ```python
 @hof1
@@ -388,7 +389,7 @@ Response body is some byte string so default `HTTPFunc` accepts `bytes`.
 
 ## set_response_header
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L122)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L124)
 
 ```python
 @hof2
@@ -413,7 +414,7 @@ Set `value` for response header `name`.
 
 ## set_response_status
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L110)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L112)
 
 ```python
 @hof1
@@ -433,7 +434,7 @@ Set response status code.
 
 ## set_started
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L144)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/context.py#L146)
 
 ```python
 @hof1

--- a/docs/moona/http/events.md
+++ b/docs/moona/http/events.md
@@ -35,7 +35,7 @@ Receive request body from client.
 
 ```python
 @handle_func
-def respond(ctx: HTTPContext) -> Future[HTTPContext | None]:
+def respond(ctx: HTTPContext) -> future[HTTPContext | None]:
 ```
 
 Send response body to the client and close the context.
@@ -56,7 +56,7 @@ Send response body to the client and close the context.
 
 ```python
 @handler
-def start(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+def start(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
 ```
 
 Send message to client and return `HTTPContext` that sent that.

--- a/docs/moona/http/handlers.md
+++ b/docs/moona/http/handlers.md
@@ -96,7 +96,7 @@ Compose 2 [HTTPHandler](#httphandler)s into one.
 [[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/handlers.py#L223)
 
 ```python
-def end(ctx: HTTPContext) -> Future[HTTPContext]:
+def end(ctx: HTTPContext) -> future[HTTPContext]:
 ```
 
 [HTTPFunc](#handlers) that finishes the pipeline of request handling.
@@ -107,7 +107,7 @@ def end(ctx: HTTPContext) -> Future[HTTPContext]:
 
 #### Returns
 
-- `Future[HTTPContext]` - ended ctx.
+- `future[HTTPContext]` - ended ctx.
 
 #### See also
 
@@ -181,7 +181,7 @@ Decorator that converts function to HTTPHandler callable.
 
 ```python
 def handler1(
-    func: Callable[[A, HTTPFunc, HTTPContext], Future[HTTPContext | None]],
+    func: Callable[[A, HTTPFunc, HTTPContext], future[HTTPContext | None]],
 ) -> Callable[[A], HTTPHandler]:
 ```
 
@@ -202,7 +202,7 @@ Makes it "curried".
 
 ```python
 def handler2(
-    func: Callable[[A, B, HTTPFunc, HTTPContext], Future[HTTPContext | None]],
+    func: Callable[[A, B, HTTPFunc, HTTPContext], future[HTTPContext | None]],
 ) -> Callable[[A, B], HTTPHandler]:
 ```
 
@@ -224,7 +224,7 @@ Makes it "curried".
 
 ```python
 def handler3(
-    func: Callable[[A, B, C, HTTPFunc, HTTPContext], Future[HTTPContext | None]],
+    func: Callable[[A, B, C, HTTPFunc, HTTPContext], future[HTTPContext | None]],
 ) -> Callable[[A, B, C], HTTPHandler]:
 ```
 
@@ -246,7 +246,7 @@ Makes it "curried".
 [[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/handlers.py#L211)
 
 ```python
-def skip(_: HTTPContext) -> Future[None]:
+def skip(_: HTTPContext) -> future[None]:
 ```
 
 [HTTPFunc](#handlers) that skips pipeline by returning `None` instead of context.
@@ -257,7 +257,7 @@ def skip(_: HTTPContext) -> Future[None]:
 
 #### Returns
 
-- `Future[None]` - result.
+- `future[None]` - result.
 
 #### See also
 

--- a/docs/moona/http/handlers.md
+++ b/docs/moona/http/handlers.md
@@ -18,7 +18,7 @@
 
 ## HTTPHandler
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/handlers.py#L41)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/handlers.py#L40)
 
 ```python
 dataclass(frozen=True, slots=True)
@@ -30,7 +30,7 @@ Abstraction over function that hander `HTTPContext`.
 
 ### HTTPHandler().compose
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/handlers.py#L54)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/handlers.py#L53)
 
 ```python
 def compose(h: _HTTPHandler) -> HTTPHandler:
@@ -48,7 +48,7 @@ Compose 2 [HTTPHandler](#httphandler)s into one.
 
 ## choose
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/handlers.py#L141)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/handlers.py#L140)
 
 ```python
 def choose(handlers: list[HTTPHandler]) -> HTTPHandler:
@@ -70,7 +70,7 @@ Iterate though handlers till one would return some `HTTPContext`.
 
 ## compose
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/handlers.py#L15)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/handlers.py#L14)
 
 ```python
 def compose(h1: _HTTPHandler, h2: _HTTPHandler) -> HTTPHandler:
@@ -93,7 +93,7 @@ Compose 2 [HTTPHandler](#httphandler)s into one.
 
 ## end
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/handlers.py#L223)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/handlers.py#L222)
 
 ```python
 def end(ctx: HTTPContext) -> future[HTTPContext]:
@@ -115,7 +115,7 @@ def end(ctx: HTTPContext) -> future[HTTPContext]:
 
 ## handle_func
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/handlers.py#L79)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/handlers.py#L78)
 
 ```python
 def handle_func(func: HTTPFunc) -> HTTPHandler:
@@ -138,7 +138,7 @@ Converts [HTTPFunc](#handlers) to [HTTPHandler](#httphandler).
 
 ## handle_func_sync
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/handlers.py#L104)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/handlers.py#L103)
 
 ```python
 def handle_func_sync(
@@ -163,7 +163,7 @@ func (Callable[[HTTPContext], HTTPContext | None]): to convert to [HTTPHandler](
 
 ## handler
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/handlers.py#L74)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/handlers.py#L73)
 
 ```python
 def handler(func: _HTTPHandler) -> HTTPHandler:
@@ -177,7 +177,7 @@ Decorator that converts function to HTTPHandler callable.
 
 ## handler1
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/handlers.py#L169)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/handlers.py#L168)
 
 ```python
 def handler1(
@@ -198,7 +198,7 @@ Makes it "curried".
 
 ## handler2
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/handlers.py#L183)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/handlers.py#L182)
 
 ```python
 def handler2(
@@ -220,7 +220,7 @@ Makes it "curried".
 
 ## handler3
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/handlers.py#L197)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/handlers.py#L196)
 
 ```python
 def handler3(
@@ -243,7 +243,7 @@ Makes it "curried".
 
 ## skip
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/handlers.py#L211)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/http/handlers.py#L210)
 
 ```python
 def skip(_: HTTPContext) -> future[None]:

--- a/docs/moona/http/request_method.md
+++ b/docs/moona/http/request_method.md
@@ -20,7 +20,7 @@
 
 ```python
 @handler
-def CONNECT(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+def CONNECT(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
 ```
 
 Matches request with CONNECT method.
@@ -42,7 +42,7 @@ Matches request with CONNECT method.
 
 ```python
 @handler
-def DELETE(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+def DELETE(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
 ```
 
 Matches request with DELETE method.
@@ -64,7 +64,7 @@ Matches request with DELETE method.
 
 ```python
 @handler
-def GET(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+def GET(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
 ```
 
 Matches request with GET method.
@@ -86,7 +86,7 @@ Matches request with GET method.
 
 ```python
 @handler
-def HEAD(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+def HEAD(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
 ```
 
 Matches request with HEAD method.
@@ -108,7 +108,7 @@ Matches request with HEAD method.
 
 ```python
 @handler
-def OPTIONS(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+def OPTIONS(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
 ```
 
 Matches request with OPTIONS method.
@@ -130,7 +130,7 @@ Matches request with OPTIONS method.
 
 ```python
 @handler
-def PATCH(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+def PATCH(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
 ```
 
 Matches request with PATCH method.
@@ -152,7 +152,7 @@ Matches request with PATCH method.
 
 ```python
 @handler
-def POST(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+def POST(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
 ```
 
 Matches request with POST method.
@@ -174,7 +174,7 @@ Matches request with POST method.
 
 ```python
 @handler
-def PUT(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+def PUT(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
 ```
 
 Matches request with PUT method.
@@ -196,7 +196,7 @@ Matches request with PUT method.
 
 ```python
 @handler
-def TRACE(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+def TRACE(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
 ```
 
 Matches request with TRACE method.
@@ -222,7 +222,7 @@ def method(
     method: str,
     nxt: HTTPFunc,
     ctx: HTTPContext,
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
 ```
 
 Handler that matches request method with passed method.
@@ -237,7 +237,7 @@ When methods are equal pipeline is continued, otherwise skipped.
 
 #### Returns
 
-Future[HTTPContext | None]: result.
+future[HTTPContext | None]: result.
 
 #### See also
 

--- a/docs/moona/http/request_route.md
+++ b/docs/moona/http/request_route.md
@@ -57,7 +57,7 @@ def route(
     path: str,
     nxt: HTTPFunc,
     ctx: HTTPContext,
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
 ```
 
 Handler that processes ctx only on right path.
@@ -82,7 +82,7 @@ def route_ci(
     path: str,
     nxt: HTTPFunc,
     ctx: HTTPContext,
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
 ```
 
 Handler that processes ctx only on right path.
@@ -107,7 +107,7 @@ def subroute(
     path: str,
     nxt: HTTPFunc,
     ctx: HTTPContext,
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
 ```
 
 Handler that proceeds only when Request path starts with passed path.
@@ -132,7 +132,7 @@ def subroute_ci(
     path: str,
     nxt: HTTPFunc,
     ctx: HTTPContext,
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
 ```
 
 Handler that proceeds only when Request path starts with passed path.

--- a/docs/moona/http/response_body.md
+++ b/docs/moona/http/response_body.md
@@ -97,7 +97,7 @@ def set_raw(
     data: bytes,
     nxt: HTTPFunc,
     ctx: HTTPContext,
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
 ```
 
 Sets response body to passed `bytes`.

--- a/docs/moona/http/response_headers.md
+++ b/docs/moona/http/response_headers.md
@@ -76,7 +76,7 @@ def content_type(value: str):
 def content_type_application_json(
     nxt: HTTPFunc,
     ctx: HTTPContext,
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
 ```
 
 Sets "Content-Type: application/json" response header.
@@ -88,7 +88,7 @@ Sets "Content-Type: application/json" response header.
 
 #### Returns
 
-Future[HTTPContext | None]: result
+future[HTTPContext | None]: result
 
 #### See also
 
@@ -103,7 +103,7 @@ Future[HTTPContext | None]: result
 def content_type_text_plain(
     nxt: HTTPFunc,
     ctx: HTTPContext,
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
 ```
 
 Sets "Content-Type: text/plain" response header.
@@ -115,7 +115,7 @@ Sets "Content-Type: text/plain" response header.
 
 #### Returns
 
-Future[HTTPContext | None]: result.
+future[HTTPContext | None]: result.
 
 #### See also
 
@@ -133,7 +133,7 @@ def header(
     value: str,
     nxt: HTTPFunc,
     ctx: HTTPContext,
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
 ```
 
 `HTTPHandler` that sets response header.
@@ -147,7 +147,7 @@ def header(
 
 #### Returns
 
-Future[HTTPContext | None]: result.
+future[HTTPContext | None]: result.
 
 #### See also
 

--- a/docs/moona/http/response_status.md
+++ b/docs/moona/http/response_status.md
@@ -273,7 +273,7 @@ data (bytes | str | BaseModel): to respond with.
 
 ```python
 @handler
-def no_content(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+def no_content(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
 ```
 
 Sets status code NO_CONTENT and respond with passed data.
@@ -406,7 +406,7 @@ data (bytes | str | BaseModel): to respond with.
 def set_accepted(
     nxt: HTTPFunc,
     ctx: HTTPContext,
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
 ```
 
 Sets response status code to ACCEPTED.
@@ -431,7 +431,7 @@ Sets response status code to ACCEPTED.
 def set_bad_gateway(
     nxt: HTTPFunc,
     ctx: HTTPContext,
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
 ```
 
 Sets response status code to BAD_GATEWAY.
@@ -456,7 +456,7 @@ Sets response status code to BAD_GATEWAY.
 def set_bad_request(
     nxt: HTTPFunc,
     ctx: HTTPContext,
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
 ```
 
 Sets response status code to BAD_REQUEST.
@@ -481,7 +481,7 @@ Sets response status code to BAD_REQUEST.
 def set_conflict(
     nxt: HTTPFunc,
     ctx: HTTPContext,
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
 ```
 
 Sets response status code to CONFLICT.
@@ -506,7 +506,7 @@ Sets response status code to CONFLICT.
 def set_created(
     nxt: HTTPFunc,
     ctx: HTTPContext,
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
 ```
 
 Sets response status code to CREATED.
@@ -531,7 +531,7 @@ Sets response status code to CREATED.
 def set_forbidden(
     nxt: HTTPFunc,
     ctx: HTTPContext,
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
 ```
 
 Sets response status code to FORBIDDEN.
@@ -556,7 +556,7 @@ Sets response status code to FORBIDDEN.
 def set_gateway_timeout(
     nxt: HTTPFunc,
     ctx: HTTPContext,
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
 ```
 
 Sets response status code to GATEWAY_TIMEOUT.
@@ -578,7 +578,7 @@ Sets response status code to GATEWAY_TIMEOUT.
 
 ```python
 @handler
-def set_gone(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+def set_gone(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
 ```
 
 Sets response status code to GONE.
@@ -603,7 +603,7 @@ Sets response status code to GONE.
 def set_http_version_not_supported(
     nxt: HTTPFunc,
     ctx: HTTPContext,
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
 ```
 
 Sets response status code to HTTP_VERSION_NOT_SUPPORTED.
@@ -628,7 +628,7 @@ Sets response status code to HTTP_VERSION_NOT_SUPPORTED.
 def set_im_a_teapot(
     nxt: HTTPFunc,
     ctx: HTTPContext,
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
 ```
 
 Sets response status code to IM_A_TEAPOT.
@@ -653,7 +653,7 @@ Sets response status code to IM_A_TEAPOT.
 def set_internal_server_error(
     nxt: HTTPFunc,
     ctx: HTTPContext,
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
 ```
 
 Sets response status code to INTERNAL_SERVER_ERROR.
@@ -678,7 +678,7 @@ Sets response status code to INTERNAL_SERVER_ERROR.
 def set_method_not_allowed(
     nxt: HTTPFunc,
     ctx: HTTPContext,
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
 ```
 
 Sets response status code to METHOD_NOT_ALLOWED.
@@ -703,7 +703,7 @@ Sets response status code to METHOD_NOT_ALLOWED.
 def set_no_content(
     nxt: HTTPFunc,
     ctx: HTTPContext,
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
 ```
 
 Sets response status code to NO_CONTENT.
@@ -728,7 +728,7 @@ Sets response status code to NO_CONTENT.
 def set_not_acceptable(
     nxt: HTTPFunc,
     ctx: HTTPContext,
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
 ```
 
 Sets response status code to NOT_ACCEPTABLE.
@@ -753,7 +753,7 @@ Sets response status code to NOT_ACCEPTABLE.
 def set_not_found(
     nxt: HTTPFunc,
     ctx: HTTPContext,
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
 ```
 
 Sets response status code to NOT_FOUND.
@@ -778,7 +778,7 @@ Sets response status code to NOT_FOUND.
 def set_not_implemented(
     nxt: HTTPFunc,
     ctx: HTTPContext,
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
 ```
 
 Sets response status code to NOT_IMPLEMENTED.
@@ -800,7 +800,7 @@ Sets response status code to NOT_IMPLEMENTED.
 
 ```python
 @handler
-def set_ok(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+def set_ok(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
 ```
 
 Sets response status code to OK.
@@ -825,7 +825,7 @@ Sets response status code to OK.
 def set_precondition_required(
     nxt: HTTPFunc,
     ctx: HTTPContext,
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
 ```
 
 Sets response status code to PRECONDITION_REQUIRED.
@@ -850,7 +850,7 @@ Sets response status code to PRECONDITION_REQUIRED.
 def set_service_unavailable(
     nxt: HTTPFunc,
     ctx: HTTPContext,
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
 ```
 
 Sets response status code to SERVICE_UNAVAILABLE.
@@ -876,7 +876,7 @@ def set_status(
     code: int,
     nxt: HTTPFunc,
     ctx: HTTPContext,
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
 ```
 
 Set response status to `code`.
@@ -896,7 +896,7 @@ Set response status to `code`.
 def set_too_many_requests(
     nxt: HTTPFunc,
     ctx: HTTPContext,
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
 ```
 
 Sets response status code to TOO_MANY_REQUESTS.
@@ -921,7 +921,7 @@ Sets response status code to TOO_MANY_REQUESTS.
 def set_unauthorized(
     nxt: HTTPFunc,
     ctx: HTTPContext,
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
 ```
 
 Sets response status code to UNAUTHORIZED.
@@ -946,7 +946,7 @@ Sets response status code to UNAUTHORIZED.
 def set_unprocessable_entity(
     nxt: HTTPFunc,
     ctx: HTTPContext,
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
 ```
 
 Sets response status code to UNPROCESSABLE_ENTITY.
@@ -971,7 +971,7 @@ Sets response status code to UNPROCESSABLE_ENTITY.
 def set_unsupported_media_type(
     nxt: HTTPFunc,
     ctx: HTTPContext,
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
 ```
 
 Sets response status code to UNSUPPORTED_MEDIA_TYPE.

--- a/docs/moona/lifespan/handlers.md
+++ b/docs/moona/lifespan/handlers.md
@@ -18,7 +18,7 @@
 
 ## LifespanHandler
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/lifespan/handlers.py#L41)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/lifespan/handlers.py#L40)
 
 ```python
 dataclass(frozen=True, slots=True)
@@ -30,7 +30,7 @@ Abstraction over function that hander `LifespanContext`.
 
 ### LifespanHandler().compose
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/lifespan/handlers.py#L54)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/lifespan/handlers.py#L53)
 
 ```python
 def compose(h: _LifespanHandler) -> LifespanHandler:
@@ -48,7 +48,7 @@ Compose 2 [LifespanHandler](#lifespanhandler)s into one.
 
 ## choose
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/lifespan/handlers.py#L141)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/lifespan/handlers.py#L140)
 
 ```python
 def choose(handlers: list[LifespanHandler]) -> LifespanHandler:
@@ -70,7 +70,7 @@ Iterate though handlers till one would return some `LifespanContext`.
 
 ## compose
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/lifespan/handlers.py#L18)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/lifespan/handlers.py#L17)
 
 ```python
 def compose(h1: _LifespanHandler, h2: _LifespanHandler) -> LifespanHandler:
@@ -93,7 +93,7 @@ Compose 2 [LifespanHandler](#lifespanhandler)s into one.
 
 ## end
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/lifespan/handlers.py#L229)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/lifespan/handlers.py#L228)
 
 ```python
 def end(ctx: LifespanContext) -> future[LifespanContext]:
@@ -111,7 +111,7 @@ def end(ctx: LifespanContext) -> future[LifespanContext]:
 
 ## handle_func
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/lifespan/handlers.py#L79)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/lifespan/handlers.py#L78)
 
 ```python
 def handle_func(func: LifespanFunc) -> LifespanHandler:
@@ -134,7 +134,7 @@ Converts [LifespanFunc](#handlers) to [LifespanHandler](#lifespanhandler).
 
 ## handle_func_sync
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/lifespan/handlers.py#L102)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/lifespan/handlers.py#L101)
 
 ```python
 def handle_func_sync(
@@ -159,7 +159,7 @@ func (Callable[[LifespanContext], LifespanContext | None]): to convert to
 
 ## handler
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/lifespan/handlers.py#L74)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/lifespan/handlers.py#L73)
 
 ```python
 def handler(func: _LifespanHandler) -> LifespanHandler:
@@ -173,7 +173,7 @@ Decorator that converts function to LifespanHandler callable.
 
 ## handler1
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/lifespan/handlers.py#L171)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/lifespan/handlers.py#L170)
 
 ```python
 def handler1(
@@ -200,7 +200,7 @@ Makes it "curried".
 
 ## handler2
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/lifespan/handlers.py#L185)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/lifespan/handlers.py#L184)
 
 ```python
 def handler2(
@@ -229,7 +229,7 @@ Makes it "curried".
 
 ## handler3
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/lifespan/handlers.py#L201)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/lifespan/handlers.py#L200)
 
 ```python
 def handler3(
@@ -260,7 +260,7 @@ Makes it "curried".
 
 ## skip
 
-[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/lifespan/handlers.py#L217)
+[[find in source code]](https://github.com/katunilya/moona/blob/main/moona/lifespan/handlers.py#L216)
 
 ```python
 def skip(_: LifespanContext) -> future[None]:

--- a/docs/moona/lifespan/handlers.md
+++ b/docs/moona/lifespan/handlers.md
@@ -96,7 +96,7 @@ Compose 2 [LifespanHandler](#lifespanhandler)s into one.
 [[find in source code]](https://github.com/katunilya/moona/blob/main/moona/lifespan/handlers.py#L229)
 
 ```python
-def end(ctx: LifespanContext) -> Future[LifespanContext]:
+def end(ctx: LifespanContext) -> future[LifespanContext]:
 ```
 
 [LifespanFunc](#handlers) that finishes the pipeline of request handling.
@@ -107,7 +107,7 @@ def end(ctx: LifespanContext) -> Future[LifespanContext]:
 
 #### Returns
 
-- `Future[LifespanContext]` - ended ctx.
+- `future[LifespanContext]` - ended ctx.
 
 ## handle_func
 
@@ -183,7 +183,7 @@ def handler1(
             LifespanFunc,
             LifespanContext,
         ],
-        Future[LifespanContext | None],
+        future[LifespanContext | None],
     ],
 ) -> Callable[[A], LifespanHandler]:
 ```
@@ -211,7 +211,7 @@ def handler2(
             LifespanFunc,
             LifespanContext,
         ],
-        Future[LifespanContext | None],
+        future[LifespanContext | None],
     ],
 ) -> Callable[[A, B], LifespanHandler]:
 ```
@@ -241,7 +241,7 @@ def handler3(
             LifespanFunc,
             LifespanContext,
         ],
-        Future[LifespanContext | None],
+        future[LifespanContext | None],
     ],
 ) -> Callable[[A, B, C], LifespanHandler]:
 ```
@@ -263,7 +263,7 @@ Makes it "curried".
 [[find in source code]](https://github.com/katunilya/moona/blob/main/moona/lifespan/handlers.py#L217)
 
 ```python
-def skip(_: LifespanContext) -> Future[None]:
+def skip(_: LifespanContext) -> future[None]:
 ```
 
 [LifespanFunc](#handlers) that skips pipeline by returning `None` instead of context.
@@ -274,4 +274,4 @@ def skip(_: LifespanContext) -> Future[None]:
 
 #### Returns
 
-- `Future[None]` - result.
+- `future[None]` - result.

--- a/docs/moona/utils.md
+++ b/docs/moona/utils.md
@@ -12,7 +12,7 @@
 [[find in source code]](https://github.com/katunilya/moona/blob/main/moona/utils.py#L6)
 
 ```python
-@hof_2
+@hof1
 def decode(encoding: str, data: bytes) -> str:
 ```
 
@@ -21,7 +21,7 @@ def decode(encoding: str, data: bytes) -> str:
 [[find in source code]](https://github.com/katunilya/moona/blob/main/moona/utils.py#L11)
 
 ```python
-@hof_2
+@hof1
 def encode(encoding: str, data: str) -> bytes:
 ```
 
@@ -30,6 +30,6 @@ def encode(encoding: str, data: str) -> bytes:
 [[find in source code]](https://github.com/katunilya/moona/blob/main/moona/utils.py#L16)
 
 ```python
-@hof_2
+@hof1
 def str_split(separator: str, data: str) -> Iterable[str]:
 ```

--- a/moona/asgi.py
+++ b/moona/asgi.py
@@ -53,7 +53,7 @@ def create(
     """Constructs ASGI Server function from passed handler.
 
     Supports 2 types of request scopes: "http" and "lifetime". For "http" scope
-    `HTTPContext` is created and used as an argument for the `handler` (via `Future`).
+    `HTTPContext` is created and used as an argument for the `handler` (via `future`).
     For "lifetime" `LifetimeContext` is created and also used as argument for `handler`.
 
     Notes:

--- a/moona/http/context.py
+++ b/moona/http/context.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import NamedTuple, TypeVar
 
-from pymon.core import Future, hof_2, hof_3, returns
+from fundom import future, hof1, hof2
 from toolz import keymap
 
 from moona.context import BaseContext, Message, Receive, Scope, Send
@@ -79,8 +79,9 @@ class HTTPContext(BaseContext):
         self.closed = False
 
 
-@hof_2
-def send_message(msg: Message, ctx: HTTPContext) -> Future[HTTPContext]:
+@hof1
+@future.returns
+async def send_message(msg: Message, ctx: HTTPContext) -> HTTPContext:
     """Sends message from `HTTPContext` to client.
 
     Args:
@@ -90,10 +91,11 @@ def send_message(msg: Message, ctx: HTTPContext) -> Future[HTTPContext]:
     Returns:
         HTTPContext: context.
     """
-    return Future(ctx.send(msg)) << returns(ctx)
+    await future(ctx.send(msg))
+    return ctx
 
 
-@hof_2
+@hof1
 def set_response_body(data: bytes, ctx: HTTPContext) -> HTTPContext:
     """Set response body.
 
@@ -107,7 +109,7 @@ def set_response_body(data: bytes, ctx: HTTPContext) -> HTTPContext:
     return ctx
 
 
-@hof_2
+@hof1
 def set_response_status(code: int, ctx: HTTPContext) -> HTTPContext:
     """Set response status code.
 
@@ -119,7 +121,7 @@ def set_response_status(code: int, ctx: HTTPContext) -> HTTPContext:
     return ctx
 
 
-@hof_3
+@hof2
 def set_response_header(name: str, value: str, ctx: HTTPContext) -> HTTPContext:
     """Set `value` for response header `name`.
 
@@ -134,21 +136,21 @@ def set_response_header(name: str, value: str, ctx: HTTPContext) -> HTTPContext:
     return ctx
 
 
-@hof_2
+@hof1
 def set_received(value: bool, ctx: HTTPContext) -> HTTPContext:
     """Sync `HTTPContext` that sets `received` to `value`."""
     ctx.received = value
     return ctx
 
 
-@hof_2
+@hof1
 def set_started(value: bool, ctx: HTTPContext) -> HTTPContext:
     """Sync `HTTPContext` that sets `started` to `value`."""
     ctx.started = value
     return ctx
 
 
-@hof_2
+@hof1
 def set_closed(value: bool, ctx: HTTPContext) -> HTTPContext:
     """Sync `HTTPContext` that sets `closed` to `value`."""
     ctx.closed = value

--- a/moona/http/events.py
+++ b/moona/http/events.py
@@ -1,4 +1,4 @@
-from pymon.core import Future, Pipe
+from fundom.core import future, pipe
 
 from moona.http.context import (
     HTTPContext,
@@ -13,7 +13,7 @@ from moona.http.handlers import HTTPFunc, handle_func, handler, skip
 
 
 @handler
-def start(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+def start(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
     """Send message to client and return `HTTPContext` that sent that.
 
     Args:
@@ -29,11 +29,11 @@ def start(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
                 "headers": list(ctx.response_headers.items()),
                 "status": ctx.response_status,
             }
-            return Pipe(ctx) << set_started(True) >> send_message(message) >> nxt
+            return pipe(ctx) << set_started(True) >> send_message(message) >> nxt
 
 
 @handle_func
-def respond(ctx: HTTPContext) -> Future[HTTPContext | None]:
+def respond(ctx: HTTPContext) -> future[HTTPContext | None]:
     """Send response body to the client and close the context.
 
     Args:
@@ -41,7 +41,7 @@ def respond(ctx: HTTPContext) -> Future[HTTPContext | None]:
         ctx (HTTPContext): context to send body from.
     """
     return (
-        Pipe(ctx)
+        pipe(ctx)
         << set_closed(True)
         >> send_message({"type": "http.response.body", "body": ctx.response_body})
     )
@@ -65,8 +65,8 @@ async def receive(nxt: HTTPFunc, ctx: HTTPContext) -> HTTPContext | None:
                         case True:
                             return await receive(nxt, ctx)
                         case False:
-                            return await (Pipe(ctx) << set_received(True) >> nxt)
+                            return await (pipe(ctx) << set_received(True) >> nxt)
                 case {"type": "http.disconnect"}:
-                    return await (Pipe(ctx) << set_closed(True) >> skip)
+                    return await (pipe(ctx) << set_closed(True) >> skip)
         case True:
             return await nxt(ctx)

--- a/moona/http/request_body.py
+++ b/moona/http/request_body.py
@@ -2,8 +2,8 @@ from logging.handlers import HTTPHandler
 from typing import Callable, Type, TypeVar
 
 import orjson
+from fundom import future, pipe
 from pydantic import BaseModel
-from pymon import Future, Pipe
 
 from moona.http.context import HTTPContext, get_request_body
 from moona.http.events import receive
@@ -22,8 +22,8 @@ def bind_raw(func: Callable[[bytes], HTTPHandler]) -> HTTPHandler:
     """
 
     @handler
-    def _handler(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
-        handle = (Pipe(ctx) << get_request_body << func).finish()
+    def _handler(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
+        handle = (pipe(ctx) << get_request_body << func).finish()
         return handle(nxt, ctx)
 
     return receive >> _handler
@@ -37,8 +37,8 @@ def bind_text(func: Callable[[str], HTTPHandler]) -> HTTPHandler:
     """
 
     @handler
-    def _handler(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
-        handle = (Pipe(ctx) << get_request_body << _decode_bytes << func).finish()
+    def _handler(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
+        handle = (pipe(ctx) << get_request_body << _decode_bytes << func).finish()
         return handle(nxt, ctx)
 
     return receive >> _handler
@@ -52,9 +52,9 @@ def bind_int(func: Callable[[int], HTTPHandler]) -> HTTPHandler:
     """
 
     @handler
-    def _handler(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+    def _handler(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
         handle = (
-            Pipe(ctx) << get_request_body << _decode_bytes << int << func
+            pipe(ctx) << get_request_body << _decode_bytes << int << func
         ).finish()
         return handle(nxt, ctx)
 
@@ -69,8 +69,8 @@ def bind_dict(func: Callable[[dict], HTTPHandler]) -> HTTPHandler:
     """
 
     @handler
-    def _handler(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
-        handle = (Pipe(ctx) << get_request_body << orjson.loads << func).finish()
+    def _handler(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
+        handle = (pipe(ctx) << get_request_body << orjson.loads << func).finish()
         return handle(nxt, ctx)
 
     return receive >> _handler
@@ -91,9 +91,9 @@ def bind_model(
     """
 
     @handler
-    def _handler(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+    def _handler(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
         handle = (
-            Pipe(ctx) << get_request_body << orjson.loads << model.parse_obj << func
+            pipe(ctx) << get_request_body << orjson.loads << model.parse_obj << func
         ).finish()
         return handle(nxt, ctx)
 

--- a/moona/http/request_headers.py
+++ b/moona/http/request_headers.py
@@ -1,6 +1,6 @@
 from logging.handlers import HTTPHandler
 
-from pymon import Future
+from fundom import future
 
 from moona.http.context import HTTPContext
 from moona.http.handlers import HTTPFunc, handler, skip
@@ -15,7 +15,7 @@ def has_header(name: str) -> HTTPHandler:
     raw_name = name.encode("UTF-8").lower()
 
     @handler
-    def _handler(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+    def _handler(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
         match ctx.request_headers.get(raw_name, None):
             case None:
                 return skip(ctx)
@@ -37,7 +37,7 @@ def matches_header(name: str, value: str) -> HTTPHandler:
     raw_value = value.encode("UTF-8")
 
     @handler
-    def _handler(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+    def _handler(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
         match ctx.request_headers.get(raw_name, None) == raw_value:
             case True:
                 return nxt(ctx)

--- a/moona/http/request_method.py
+++ b/moona/http/request_method.py
@@ -1,11 +1,11 @@
-from pymon import Future
+from fundom import future
 
 from moona.http.context import HTTPContext
 from moona.http.handlers import HTTPFunc, handler, handler1, skip
 
 
 @handler1
-def method(method: str, nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+def method(method: str, nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
     """Handler that matches request method with passed method.
 
     When methods are equal pipeline is continued, otherwise skipped.
@@ -16,7 +16,7 @@ def method(method: str, nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext |
         ctx (HTTPContext): to match with
 
     Returns:
-        Future[HTTPContext | None]: result.
+        future[HTTPContext | None]: result.
     """
     match ctx.request_method == method:
         case True:
@@ -26,7 +26,7 @@ def method(method: str, nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext |
 
 
 @handler
-def GET(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:  # noqa
+def GET(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:  # noqa
     """Matches request with GET method.
 
     Args:
@@ -37,7 +37,7 @@ def GET(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:  # noqa
 
 
 @handler
-def POST(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:  # noqa
+def POST(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:  # noqa
     """Matches request with POST method.
 
     Args:
@@ -48,7 +48,7 @@ def POST(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:  # noqa
 
 
 @handler
-def PATCH(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:  # noqa
+def PATCH(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:  # noqa
     """Matches request with PATCH method.
 
     Args:
@@ -59,7 +59,7 @@ def PATCH(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:  # noq
 
 
 @handler
-def PUT(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:  # noqa
+def PUT(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:  # noqa
     """Matches request with PUT method.
 
     Args:
@@ -70,7 +70,7 @@ def PUT(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:  # noqa
 
 
 @handler
-def DELETE(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:  # noqa
+def DELETE(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:  # noqa
     """Matches request with DELETE method.
 
     Args:
@@ -81,7 +81,7 @@ def DELETE(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:  # no
 
 
 @handler
-def OPTIONS(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:  # noqa
+def OPTIONS(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:  # noqa
     """Matches request with OPTIONS method.
 
     Args:
@@ -92,7 +92,7 @@ def OPTIONS(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:  # n
 
 
 @handler
-def HEAD(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:  # noqa
+def HEAD(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:  # noqa
     """Matches request with HEAD method.
 
     Args:
@@ -103,7 +103,7 @@ def HEAD(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:  # noqa
 
 
 @handler
-def TRACE(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:  # noqa
+def TRACE(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:  # noqa
     """Matches request with TRACE method.
 
     Args:
@@ -114,7 +114,7 @@ def TRACE(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:  # noq
 
 
 @handler
-def CONNECT(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:  # noqa
+def CONNECT(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:  # noqa
     """Matches request with CONNECT method.
 
     Args:

--- a/moona/http/request_route.py
+++ b/moona/http/request_route.py
@@ -1,6 +1,6 @@
 from typing import Callable
 
-from pymon import Future, Pipe, cmap
+from fundom import cmap, future, pipe
 
 from moona.http.context import HTTPContext, get_request_path, get_request_query_string
 from moona.http.handlers import HTTPFunc, HTTPHandler, handler, handler1, skip
@@ -8,7 +8,7 @@ from moona.utils import decode, str_split
 
 
 @handler1
-def route(path: str, nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+def route(path: str, nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
     """Handler that processes ctx only on right path.
 
     Request path must be exactly the same as path passed as an argument to the handler
@@ -23,7 +23,7 @@ def route(path: str, nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | No
 
 
 @handler1
-def subroute(path: str, nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+def subroute(path: str, nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
     """Handler that proceeds only when Request path starts with passed path.
 
     Leading part of the path is removed after processing the request. For example
@@ -40,7 +40,7 @@ def subroute(path: str, nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext |
 
 
 @handler1
-def route_ci(path: str, nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+def route_ci(path: str, nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
     """Handler that processes ctx only on right path.
 
     Request path must be case-insensitive to path passed as an argument to the handler
@@ -57,7 +57,7 @@ def route_ci(path: str, nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext |
 @handler1
 def subroute_ci(
     path: str, nxt: HTTPFunc, ctx: HTTPContext
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
     """Handler that proceeds only when Request path starts with passed path.
 
     Leading part of the path is removed after processing the request. For example
@@ -82,18 +82,18 @@ def bind_query(func: Callable[..., HTTPHandler]) -> HTTPHandler:
     """
 
     @handler
-    def _handler(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+    def _handler(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
         match get_request_query_string(ctx):
             case b"":
                 query = {}
             case raw_query:
                 query = (
-                    Pipe(raw_query)
-                    .then(decode("UTF-8"))
-                    .then(str_split("&"))
-                    .then(cmap(str_split("=")))
-                    .then(list)
-                    .then(dict)
+                    pipe(raw_query)
+                    << decode("UTF-8")
+                    << str_split("&")
+                    << cmap(str_split("="))
+                    << list
+                    << dict
                 ).finish()
 
         handle = func(**query)
@@ -112,7 +112,7 @@ def bind_params(path: str, func: Callable[..., HTTPHandler]) -> HTTPHandler:
     path_parts = path.strip("/").split("/")
 
     @handler
-    def _handler(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+    def _handler(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
         request_path_parts = get_request_path(ctx).strip("/").split("/")
         params = ()
         match len(request_path_parts) == len(path_parts):

--- a/moona/http/response_body.py
+++ b/moona/http/response_body.py
@@ -1,6 +1,6 @@
 import orjson
+from fundom import future, pipe
 from pydantic import BaseModel
-from pymon import Future, Pipe
 
 from moona.http.context import HTTPContext, set_response_body
 from moona.http.events import respond, start
@@ -12,7 +12,7 @@ from moona.http.response_headers import (
 
 
 @handler1
-def set_raw(data: bytes, nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+def set_raw(data: bytes, nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
     """Sets response body to passed `bytes`.
 
     Args:
@@ -20,7 +20,7 @@ def set_raw(data: bytes, nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext 
         nxt (HTTPFunc): to run next.
         ctx (HTTPContext): to run on.
     """
-    return Pipe(ctx) << set_response_body(data) >> nxt
+    return pipe(ctx) << set_response_body(data) >> nxt
 
 
 def set_text(data: str) -> HTTPHandler:
@@ -42,7 +42,7 @@ def set_json(data: BaseModel) -> HTTPHandler:
     Args:
         data (BaseModel): body.
     """
-    raw = Pipe(data) << BaseModel.dict << orjson.dumps
+    raw = pipe(data) << BaseModel.dict << orjson.dumps
     return set_raw(raw.value) >> content_type_application_json
 
 

--- a/moona/http/response_headers.py
+++ b/moona/http/response_headers.py
@@ -1,4 +1,4 @@
-from pymon import Future, Pipe
+from fundom import future, pipe
 
 from moona.http.context import HTTPContext, get_response_body, set_response_header
 from moona.http.handlers import HTTPFunc, HTTPHandler, handle_func_sync, handler2
@@ -10,7 +10,7 @@ def header(
     value: str,
     nxt: HTTPFunc,
     ctx: HTTPContext,
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
     """`HTTPHandler` that sets response header.
 
     Args:
@@ -20,9 +20,9 @@ def header(
         ctx (HTTPContext): to process.
 
     Returns:
-        Future[HTTPContext | None]: result.
+        future[HTTPContext | None]: result.
     """
-    return Pipe(ctx) << set_response_header(name, value) >> nxt
+    return pipe(ctx) << set_response_header(name, value) >> nxt
 
 
 def content_type(value: str):
@@ -39,7 +39,7 @@ def content_type(value: str):
 
 def content_type_application_json(
     nxt: HTTPFunc, ctx: HTTPContext
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
     """Sets "Content-Type: application/json" response header.
 
     Args:
@@ -47,14 +47,14 @@ def content_type_application_json(
         ctx (HTTPContext): to process.
 
     Returns:
-        Future[HTTPContext | None]: result
+        future[HTTPContext | None]: result
     """
     return content_type("application/json")(nxt, ctx)
 
 
 def content_type_text_plain(
     nxt: HTTPFunc, ctx: HTTPContext
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
     """Sets "Content-Type: text/plain" response header.
 
     Args:
@@ -62,7 +62,7 @@ def content_type_text_plain(
         ctx (HTTPContext): to process
 
     Returns:
-        Future[HTTPContext | None]: result.
+        future[HTTPContext | None]: result.
     """
     return content_type("text/plain")(nxt, ctx)
 
@@ -89,6 +89,6 @@ def auto_content_length(ctx: HTTPContext) -> HTTPContext:
         case None:
             length = "0"
         case body:
-            length = (Pipe(body) << len << str).finish()
+            length = (pipe(body) << len << str).finish()
 
-    return (Pipe(ctx) << set_response_header("content-length", length)).finish()
+    return (pipe(ctx) << set_response_header("content-length", length)).finish()

--- a/moona/http/response_status.py
+++ b/moona/http/response_status.py
@@ -1,5 +1,5 @@
+from fundom import future, pipe
 from pydantic import BaseModel
-from pymon import Future, Pipe
 
 from moona.http.context import HTTPContext, set_response_status
 from moona.http.handlers import HTTPFunc, HTTPHandler, handler, handler1
@@ -67,13 +67,13 @@ NOT_EXTENDED = 510
 @handler1
 def set_status(
     code: int, nxt: HTTPFunc, ctx: HTTPContext
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
     """Set response status to `code`."""
-    return Pipe(ctx) << set_response_status(code) >> nxt
+    return pipe(ctx) << set_response_status(code) >> nxt
 
 
 @handler
-def set_ok(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+def set_ok(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
     """Sets response status code to OK.
 
     Args:
@@ -84,7 +84,7 @@ def set_ok(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
 
 
 @handler
-def set_created(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+def set_created(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
     """Sets response status code to CREATED.
 
     Args:
@@ -95,7 +95,7 @@ def set_created(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
 
 
 @handler
-def set_accepted(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+def set_accepted(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
     """Sets response status code to ACCEPTED.
 
     Args:
@@ -106,7 +106,7 @@ def set_accepted(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
 
 
 @handler
-def set_no_content(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+def set_no_content(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
     """Sets response status code to NO_CONTENT.
 
     Args:
@@ -117,7 +117,7 @@ def set_no_content(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None
 
 
 @handler
-def set_bad_request(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+def set_bad_request(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
     """Sets response status code to BAD_REQUEST.
 
     Args:
@@ -128,7 +128,7 @@ def set_bad_request(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | Non
 
 
 @handler
-def set_unauthorized(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+def set_unauthorized(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
     """Sets response status code to UNAUTHORIZED.
 
     Args:
@@ -139,7 +139,7 @@ def set_unauthorized(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | No
 
 
 @handler
-def set_forbidden(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+def set_forbidden(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
     """Sets response status code to FORBIDDEN.
 
     Args:
@@ -150,7 +150,7 @@ def set_forbidden(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]
 
 
 @handler
-def set_not_found(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+def set_not_found(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
     """Sets response status code to NOT_FOUND.
 
     Args:
@@ -163,7 +163,7 @@ def set_not_found(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]
 @handler
 def set_method_not_allowed(
     nxt: HTTPFunc, ctx: HTTPContext
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
     """Sets response status code to METHOD_NOT_ALLOWED.
 
     Args:
@@ -174,7 +174,7 @@ def set_method_not_allowed(
 
 
 @handler
-def set_not_acceptable(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+def set_not_acceptable(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
     """Sets response status code to NOT_ACCEPTABLE.
 
     Args:
@@ -185,7 +185,7 @@ def set_not_acceptable(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | 
 
 
 @handler
-def set_conflict(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+def set_conflict(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
     """Sets response status code to CONFLICT.
 
     Args:
@@ -196,7 +196,7 @@ def set_conflict(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
 
 
 @handler
-def set_gone(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+def set_gone(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
     """Sets response status code to GONE.
 
     Args:
@@ -209,7 +209,7 @@ def set_gone(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
 @handler
 def set_unsupported_media_type(
     nxt: HTTPFunc, ctx: HTTPContext
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
     """Sets response status code to UNSUPPORTED_MEDIA_TYPE.
 
     Args:
@@ -220,7 +220,7 @@ def set_unsupported_media_type(
 
 
 @handler
-def set_im_a_teapot(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+def set_im_a_teapot(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
     """Sets response status code to IM_A_TEAPOT.
 
     Args:
@@ -233,7 +233,7 @@ def set_im_a_teapot(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | Non
 @handler
 def set_unprocessable_entity(
     nxt: HTTPFunc, ctx: HTTPContext
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
     """Sets response status code to UNPROCESSABLE_ENTITY.
 
     Args:
@@ -246,7 +246,7 @@ def set_unprocessable_entity(
 @handler
 def set_precondition_required(
     nxt: HTTPFunc, ctx: HTTPContext
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
     """Sets response status code to PRECONDITION_REQUIRED.
 
     Args:
@@ -259,7 +259,7 @@ def set_precondition_required(
 @handler
 def set_too_many_requests(
     nxt: HTTPFunc, ctx: HTTPContext
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
     """Sets response status code to TOO_MANY_REQUESTS.
 
     Args:
@@ -272,7 +272,7 @@ def set_too_many_requests(
 @handler
 def set_internal_server_error(
     nxt: HTTPFunc, ctx: HTTPContext
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
     """Sets response status code to INTERNAL_SERVER_ERROR.
 
     Args:
@@ -283,7 +283,7 @@ def set_internal_server_error(
 
 
 @handler
-def set_not_implemented(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+def set_not_implemented(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
     """Sets response status code to NOT_IMPLEMENTED.
 
     Args:
@@ -294,7 +294,7 @@ def set_not_implemented(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext |
 
 
 @handler
-def set_bad_gateway(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+def set_bad_gateway(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
     """Sets response status code to BAD_GATEWAY.
 
     Args:
@@ -307,7 +307,7 @@ def set_bad_gateway(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | Non
 @handler
 def set_service_unavailable(
     nxt: HTTPFunc, ctx: HTTPContext
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
     """Sets response status code to SERVICE_UNAVAILABLE.
 
     Args:
@@ -318,7 +318,7 @@ def set_service_unavailable(
 
 
 @handler
-def set_gateway_timeout(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+def set_gateway_timeout(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
     """Sets response status code to GATEWAY_TIMEOUT.
 
     Args:
@@ -331,7 +331,7 @@ def set_gateway_timeout(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext |
 @handler
 def set_http_version_not_supported(
     nxt: HTTPFunc, ctx: HTTPContext
-) -> Future[HTTPContext | None]:
+) -> future[HTTPContext | None]:
     """Sets response status code to HTTP_VERSION_NOT_SUPPORTED.
 
     Args:
@@ -369,7 +369,7 @@ def accepted(data: bytes | str | BaseModel) -> HTTPHandler:
 
 
 @handler
-def no_content(nxt: HTTPFunc, ctx: HTTPContext) -> Future[HTTPContext | None]:
+def no_content(nxt: HTTPFunc, ctx: HTTPContext) -> future[HTTPContext | None]:
     """Sets status code NO_CONTENT and respond with passed data.
 
     Args:

--- a/moona/utils.py
+++ b/moona/utils.py
@@ -1,18 +1,18 @@
 from typing import Iterable
 
-from pymon import hof_2
+from fundom import hof1
 
 
-@hof_2
+@hof1
 def decode(encoding: str, data: bytes) -> str:  # noqa
     return data.decode(encoding)
 
 
-@hof_2
+@hof1
 def encode(encoding: str, data: str) -> bytes:  # noqa
     return data.encode(encoding)
 
 
-@hof_2
+@hof1
 def str_split(separator: str, data: str) -> Iterable[str]:  # noqa
     return data.split(separator)

--- a/poetry.lock
+++ b/poetry.lock
@@ -144,14 +144,14 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "coverage"
-version = "6.4"
+version = "6.4.1"
 description = "Code coverage measurement for Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
-tomli = {version = "*", optional = true, markers = "python_version < \"3.11\" and extra == \"toml\""}
+tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.11.0a6\" and extra == \"toml\""}
 
 [package.extras]
 toml = ["tomli"]
@@ -639,7 +639,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pymon"
-version = "0.0.3"
+version = "0.0.5"
 description = "Common simple python monads for more readable and maintainable pipeline-based code."
 category = "main"
 optional = false
@@ -649,8 +649,8 @@ develop = false
 [package.source]
 type = "git"
 url = "https://github.com/katunilya/pymon.git"
-reference = "v0.0.3"
-resolved_reference = "ffdcd104f645597d699332b982d7c7ff115d43e0"
+reference = "v0.0.5"
+resolved_reference = "0e18973a881cf6f5c858e10d6d2ef99440d0cc48"
 
 [[package]]
 name = "pyparsing"
@@ -868,7 +868,7 @@ testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "6bd5178a9e28357f29eff45fadb6719a35bbbe459094147f3df9c1c9b668aea4"
+content-hash = "3bbfe1a5284231e6a242da2d3d41a039d9364a5571e369de13d5b11821b25490"
 
 [metadata.files]
 anyio = [
@@ -943,47 +943,47 @@ colorama = [
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 coverage = [
-    {file = "coverage-6.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:50ed480b798febce113709846b11f5d5ed1e529c88d8ae92f707806c50297abf"},
-    {file = "coverage-6.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:26f8f92699756cb7af2b30720de0c5bb8d028e923a95b6d0c891088025a1ac8f"},
-    {file = "coverage-6.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:60c2147921da7f4d2d04f570e1838db32b95c5509d248f3fe6417e91437eaf41"},
-    {file = "coverage-6.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:750e13834b597eeb8ae6e72aa58d1d831b96beec5ad1d04479ae3772373a8088"},
-    {file = "coverage-6.4-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:af5b9ee0fc146e907aa0f5fb858c3b3da9199d78b7bb2c9973d95550bd40f701"},
-    {file = "coverage-6.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:a022394996419142b33a0cf7274cb444c01d2bb123727c4bb0b9acabcb515dea"},
-    {file = "coverage-6.4-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:5a78cf2c43b13aa6b56003707c5203f28585944c277c1f3f109c7b041b16bd39"},
-    {file = "coverage-6.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:9229d074e097f21dfe0643d9d0140ee7433814b3f0fc3706b4abffd1e3038632"},
-    {file = "coverage-6.4-cp310-cp310-win32.whl", hash = "sha256:fb45fe08e1abc64eb836d187b20a59172053999823f7f6ef4f18a819c44ba16f"},
-    {file = "coverage-6.4-cp310-cp310-win_amd64.whl", hash = "sha256:3cfd07c5889ddb96a401449109a8b97a165be9d67077df6802f59708bfb07720"},
-    {file = "coverage-6.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:03014a74023abaf5a591eeeaf1ac66a73d54eba178ff4cb1fa0c0a44aae70383"},
-    {file = "coverage-6.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9c82f2cd69c71698152e943f4a5a6b83a3ab1db73b88f6e769fabc86074c3b08"},
-    {file = "coverage-6.4-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b546cf2b1974ddc2cb222a109b37c6ed1778b9be7e6b0c0bc0cf0438d9e45a6"},
-    {file = "coverage-6.4-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc173f1ce9ffb16b299f51c9ce53f66a62f4d975abe5640e976904066f3c835d"},
-    {file = "coverage-6.4-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:c53ad261dfc8695062fc8811ac7c162bd6096a05a19f26097f411bdf5747aee7"},
-    {file = "coverage-6.4-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:eef5292b60b6de753d6e7f2d128d5841c7915fb1e3321c3a1fe6acfe76c38052"},
-    {file = "coverage-6.4-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:543e172ce4c0de533fa892034cce260467b213c0ea8e39da2f65f9a477425211"},
-    {file = "coverage-6.4-cp37-cp37m-win32.whl", hash = "sha256:00c8544510f3c98476bbd58201ac2b150ffbcce46a8c3e4fb89ebf01998f806a"},
-    {file = "coverage-6.4-cp37-cp37m-win_amd64.whl", hash = "sha256:b84ab65444dcc68d761e95d4d70f3cfd347ceca5a029f2ffec37d4f124f61311"},
-    {file = "coverage-6.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d548edacbf16a8276af13063a2b0669d58bbcfca7c55a255f84aac2870786a61"},
-    {file = "coverage-6.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:033ebec282793bd9eb988d0271c211e58442c31077976c19c442e24d827d356f"},
-    {file = "coverage-6.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:742fb8b43835078dd7496c3c25a1ec8d15351df49fb0037bffb4754291ef30ce"},
-    {file = "coverage-6.4-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d55fae115ef9f67934e9f1103c9ba826b4c690e4c5bcf94482b8b2398311bf9c"},
-    {file = "coverage-6.4-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5cd698341626f3c77784858427bad0cdd54a713115b423d22ac83a28303d1d95"},
-    {file = "coverage-6.4-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:62d382f7d77eeeaff14b30516b17bcbe80f645f5cf02bb755baac376591c653c"},
-    {file = "coverage-6.4-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:016d7f5cf1c8c84f533a3c1f8f36126fbe00b2ec0ccca47cc5731c3723d327c6"},
-    {file = "coverage-6.4-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:69432946f154c6add0e9ede03cc43b96e2ef2733110a77444823c053b1ff5166"},
-    {file = "coverage-6.4-cp38-cp38-win32.whl", hash = "sha256:83bd142cdec5e4a5c4ca1d4ff6fa807d28460f9db919f9f6a31babaaa8b88426"},
-    {file = "coverage-6.4-cp38-cp38-win_amd64.whl", hash = "sha256:4002f9e8c1f286e986fe96ec58742b93484195defc01d5cc7809b8f7acb5ece3"},
-    {file = "coverage-6.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:e4f52c272fdc82e7c65ff3f17a7179bc5f710ebc8ce8a5cadac81215e8326740"},
-    {file = "coverage-6.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b5578efe4038be02d76c344007b13119b2b20acd009a88dde8adec2de4f630b5"},
-    {file = "coverage-6.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8099ea680201c2221f8468c372198ceba9338a5fec0e940111962b03b3f716a"},
-    {file = "coverage-6.4-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a00441f5ea4504f5abbc047589d09e0dc33eb447dc45a1a527c8b74bfdd32c65"},
-    {file = "coverage-6.4-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2e76bd16f0e31bc2b07e0fb1379551fcd40daf8cdf7e24f31a29e442878a827c"},
-    {file = "coverage-6.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:8d2e80dd3438e93b19e1223a9850fa65425e77f2607a364b6fd134fcd52dc9df"},
-    {file = "coverage-6.4-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:341e9c2008c481c5c72d0e0dbf64980a4b2238631a7f9780b0fe2e95755fb018"},
-    {file = "coverage-6.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:21e6686a95025927775ac501e74f5940cdf6fe052292f3a3f7349b0abae6d00f"},
-    {file = "coverage-6.4-cp39-cp39-win32.whl", hash = "sha256:968ed5407f9460bd5a591cefd1388cc00a8f5099de9e76234655ae48cfdbe2c3"},
-    {file = "coverage-6.4-cp39-cp39-win_amd64.whl", hash = "sha256:e35217031e4b534b09f9b9a5841b9344a30a6357627761d4218818b865d45055"},
-    {file = "coverage-6.4-pp36.pp37.pp38-none-any.whl", hash = "sha256:e637ae0b7b481905358624ef2e81d7fb0b1af55f5ff99f9ba05442a444b11e45"},
-    {file = "coverage-6.4.tar.gz", hash = "sha256:727dafd7f67a6e1cad808dc884bd9c5a2f6ef1f8f6d2f22b37b96cb0080d4f49"},
+    {file = "coverage-6.4.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f1d5aa2703e1dab4ae6cf416eb0095304f49d004c39e9db1d86f57924f43006b"},
+    {file = "coverage-6.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4ce1b258493cbf8aec43e9b50d89982346b98e9ffdfaae8ae5793bc112fb0068"},
+    {file = "coverage-6.4.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83c4e737f60c6936460c5be330d296dd5b48b3963f48634c53b3f7deb0f34ec4"},
+    {file = "coverage-6.4.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:84e65ef149028516c6d64461b95a8dbcfce95cfd5b9eb634320596173332ea84"},
+    {file = "coverage-6.4.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f69718750eaae75efe506406c490d6fc5a6161d047206cc63ce25527e8a3adad"},
+    {file = "coverage-6.4.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:e57816f8ffe46b1df8f12e1b348f06d164fd5219beba7d9433ba79608ef011cc"},
+    {file = "coverage-6.4.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:01c5615d13f3dd3aa8543afc069e5319cfa0c7d712f6e04b920431e5c564a749"},
+    {file = "coverage-6.4.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:75ab269400706fab15981fd4bd5080c56bd5cc07c3bccb86aab5e1d5a88dc8f4"},
+    {file = "coverage-6.4.1-cp310-cp310-win32.whl", hash = "sha256:a7f3049243783df2e6cc6deafc49ea123522b59f464831476d3d1448e30d72df"},
+    {file = "coverage-6.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:ee2ddcac99b2d2aec413e36d7a429ae9ebcadf912946b13ffa88e7d4c9b712d6"},
+    {file = "coverage-6.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fb73e0011b8793c053bfa85e53129ba5f0250fdc0392c1591fd35d915ec75c46"},
+    {file = "coverage-6.4.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:106c16dfe494de3193ec55cac9640dd039b66e196e4641fa8ac396181578b982"},
+    {file = "coverage-6.4.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:87f4f3df85aa39da00fd3ec4b5abeb7407e82b68c7c5ad181308b0e2526da5d4"},
+    {file = "coverage-6.4.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:961e2fb0680b4f5ad63234e0bf55dfb90d302740ae9c7ed0120677a94a1590cb"},
+    {file = "coverage-6.4.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:cec3a0f75c8f1031825e19cd86ee787e87cf03e4fd2865c79c057092e69e3a3b"},
+    {file = "coverage-6.4.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:129cd05ba6f0d08a766d942a9ed4b29283aff7b2cccf5b7ce279d50796860bb3"},
+    {file = "coverage-6.4.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:bf5601c33213d3cb19d17a796f8a14a9eaa5e87629a53979a5981e3e3ae166f6"},
+    {file = "coverage-6.4.1-cp37-cp37m-win32.whl", hash = "sha256:269eaa2c20a13a5bf17558d4dc91a8d078c4fa1872f25303dddcbba3a813085e"},
+    {file = "coverage-6.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:f02cbbf8119db68455b9d763f2f8737bb7db7e43720afa07d8eb1604e5c5ae28"},
+    {file = "coverage-6.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ffa9297c3a453fba4717d06df579af42ab9a28022444cae7fa605af4df612d54"},
+    {file = "coverage-6.4.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:145f296d00441ca703a659e8f3eb48ae39fb083baba2d7ce4482fb2723e050d9"},
+    {file = "coverage-6.4.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d67d44996140af8b84284e5e7d398e589574b376fb4de8ccd28d82ad8e3bea13"},
+    {file = "coverage-6.4.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2bd9a6fc18aab8d2e18f89b7ff91c0f34ff4d5e0ba0b33e989b3cd4194c81fd9"},
+    {file = "coverage-6.4.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3384f2a3652cef289e38100f2d037956194a837221edd520a7ee5b42d00cc605"},
+    {file = "coverage-6.4.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:9b3e07152b4563722be523e8cd0b209e0d1a373022cfbde395ebb6575bf6790d"},
+    {file = "coverage-6.4.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:1480ff858b4113db2718848d7b2d1b75bc79895a9c22e76a221b9d8d62496428"},
+    {file = "coverage-6.4.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:865d69ae811a392f4d06bde506d531f6a28a00af36f5c8649684a9e5e4a85c83"},
+    {file = "coverage-6.4.1-cp38-cp38-win32.whl", hash = "sha256:664a47ce62fe4bef9e2d2c430306e1428ecea207ffd68649e3b942fa8ea83b0b"},
+    {file = "coverage-6.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:26dff09fb0d82693ba9e6231248641d60ba606150d02ed45110f9ec26404ed1c"},
+    {file = "coverage-6.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d9c80df769f5ec05ad21ea34be7458d1dc51ff1fb4b2219e77fe24edf462d6df"},
+    {file = "coverage-6.4.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:39ee53946bf009788108b4dd2894bf1349b4e0ca18c2016ffa7d26ce46b8f10d"},
+    {file = "coverage-6.4.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f5b66caa62922531059bc5ac04f836860412f7f88d38a476eda0a6f11d4724f4"},
+    {file = "coverage-6.4.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fd180ed867e289964404051a958f7cccabdeed423f91a899829264bb7974d3d3"},
+    {file = "coverage-6.4.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:84631e81dd053e8a0d4967cedab6db94345f1c36107c71698f746cb2636c63e3"},
+    {file = "coverage-6.4.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:8c08da0bd238f2970230c2a0d28ff0e99961598cb2e810245d7fc5afcf1254e8"},
+    {file = "coverage-6.4.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:d42c549a8f41dc103a8004b9f0c433e2086add8a719da00e246e17cbe4056f72"},
+    {file = "coverage-6.4.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:309ce4a522ed5fca432af4ebe0f32b21d6d7ccbb0f5fcc99290e71feba67c264"},
+    {file = "coverage-6.4.1-cp39-cp39-win32.whl", hash = "sha256:fdb6f7bd51c2d1714cea40718f6149ad9be6a2ee7d93b19e9f00934c0f2a74d9"},
+    {file = "coverage-6.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:342d4aefd1c3e7f620a13f4fe563154d808b69cccef415415aece4c786665397"},
+    {file = "coverage-6.4.1-pp36.pp37.pp38-none-any.whl", hash = "sha256:4803e7ccf93230accb928f3a68f00ffa80a88213af98ed338a57ad021ef06815"},
+    {file = "coverage-6.4.1.tar.gz", hash = "sha256:4321f075095a096e70aff1d002030ee612b65a205a0a0f5b815280d5dc58100c"},
 ]
 distlib = [
     {file = "distlib-0.3.4-py2.py3-none-any.whl", hash = "sha256:6564fe0a8f51e734df6333d08b8b94d4ea8ee6b99b5ed50613f731fd4089f34b"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -11,8 +11,8 @@ idna = ">=2.8"
 sniffio = ">=1.1"
 
 [package.extras]
-doc = ["packaging", "sphinx-rtd-theme", "sphinx-autodoc-typehints (>=1.2.0)"]
-test = ["coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "pytest (>=7.0)", "pytest-mock (>=3.6.1)", "trustme", "contextlib2", "uvloop (<0.15)", "mock (>=4)", "uvloop (>=0.15)"]
+doc = ["packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx-rtd-theme"]
+test = ["contextlib2", "coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "mock (>=4)", "pytest (>=7.0)", "pytest-mock (>=3.6.1)", "trustme", "uvloop (<0.15)", "uvloop (>=0.15)"]
 trio = ["trio (>=0.16)"]
 
 [[package]]
@@ -24,7 +24,7 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-tests = ["pytest", "pytest-asyncio", "mypy (>=0.800)"]
+tests = ["mypy (>=0.800)", "pytest", "pytest-asyncio"]
 
 [[package]]
 name = "asyncio"
@@ -51,10 +51,10 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
-docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
-tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
+dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six", "sphinx", "sphinx-notfound-page", "zope.interface"]
+docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
+tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six", "zope.interface"]
+tests_no_zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six"]
 
 [[package]]
 name = "bandit"
@@ -71,7 +71,7 @@ PyYAML = ">=5.3.1"
 stevedore = ">=1.20.0"
 
 [package.extras]
-test = ["coverage (>=4.5.4)", "fixtures (>=3.0.0)", "flake8 (>=4.0.0)", "stestr (>=2.5.0)", "testscenarios (>=0.5.0)", "testtools (>=2.3.0)", "toml", "beautifulsoup4 (>=4.8.0)", "pylint (==1.9.4)"]
+test = ["beautifulsoup4 (>=4.8.0)", "coverage (>=4.5.4)", "fixtures (>=3.0.0)", "flake8 (>=4.0.0)", "pylint (==1.9.4)", "stestr (>=2.5.0)", "testscenarios (>=0.5.0)", "testtools (>=2.3.0)", "toml"]
 toml = ["toml"]
 yaml = ["pyyaml"]
 
@@ -144,7 +144,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "coverage"
-version = "6.4.1"
+version = "6.4.4"
 description = "Code coverage measurement for Python"
 category = "dev"
 optional = false
@@ -340,6 +340,14 @@ python-versions = "*"
 flake8 = "*"
 
 [[package]]
+name = "fundom"
+version = "0.1.0"
+description = "Common simple python monads for more readable and maintainable pipeline-based code."
+category = "main"
+optional = false
+python-versions = ">=3.10,<4.0"
+
+[[package]]
 name = "gitdb"
 version = "4.0.9"
 description = "Git Object Database"
@@ -415,8 +423,8 @@ rfc3986 = {version = ">=1.3,<2", extras = ["idna2008"]}
 sniffio = "*"
 
 [package.extras]
-brotli = ["brotlicffi", "brotli"]
-cli = ["click (>=8.0.0,<9.0.0)", "rich (>=10.0.0,<11.0.0)", "pygments (>=2.0.0,<3.0.0)"]
+brotli = ["brotli", "brotlicffi"]
+cli = ["click (>=8.0.0,<9.0.0)", "pygments (>=2.0.0,<3.0.0)", "rich (>=10.0.0,<11.0.0)"]
 http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (>=1.0.0,<2.0.0)"]
 
@@ -448,8 +456,8 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
+docs = ["jaraco.packaging (>=9)", "rst.linker (>=1.9)", "sphinx"]
+testing = ["pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [[package]]
 name = "iniconfig"
@@ -468,10 +476,10 @@ optional = false
 python-versions = ">=3.6.1,<4.0"
 
 [package.extras]
-pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
-requirements_deprecated_finder = ["pipreqs", "pip-api"]
 colors = ["colorama (>=0.4.3,<0.5.0)"]
+pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
 plugins = ["setuptools"]
+requirements_deprecated_finder = ["pip-api", "pipreqs"]
 
 [[package]]
 name = "mccabe"
@@ -553,8 +561,8 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)", "sphinx (>=4)"]
-test = ["appdirs (==1.4.4)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)", "pytest (>=6)"]
+docs = ["furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx (>=4)", "sphinx-autodoc-typehints (>=1.12)"]
+test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)"]
 
 [[package]]
 name = "pluggy"
@@ -638,21 +646,6 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
-name = "pymon"
-version = "0.0.5"
-description = "Common simple python monads for more readable and maintainable pipeline-based code."
-category = "main"
-optional = false
-python-versions = "^3.10"
-develop = false
-
-[package.source]
-type = "git"
-url = "https://github.com/katunilya/pymon.git"
-reference = "v0.0.5"
-resolved_reference = "0e18973a881cf6f5c858e10d6d2ef99440d0cc48"
-
-[[package]]
 name = "pyparsing"
 version = "3.0.9"
 description = "pyparsing module - Classes and methods to define and execute parsing grammars"
@@ -661,7 +654,7 @@ optional = false
 python-versions = ">=3.6.8"
 
 [package.extras]
-diagrams = ["railroad-diagrams", "jinja2"]
+diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pytest"
@@ -696,7 +689,7 @@ python-versions = ">=3.7"
 pytest = ">=6.1.0"
 
 [package.extras]
-testing = ["coverage (==6.2)", "hypothesis (>=5.7.1)", "flaky (>=3.5.0)", "mypy (==0.931)", "pytest-trio (>=0.7.0)"]
+testing = ["coverage (==6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy (==0.931)", "pytest-trio (>=0.7.0)"]
 
 [[package]]
 name = "pytest-cov"
@@ -711,7 +704,7 @@ coverage = {version = ">=5.2.1", extras = ["toml"]}
 pytest = ">=4.6"
 
 [package.extras]
-testing = ["fields", "hunter", "process-tests", "six", "pytest-xdist", "virtualenv"]
+testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
 
 [[package]]
 name = "pyyaml"
@@ -787,9 +780,9 @@ optional = false
 python-versions = "*"
 
 [package.extras]
-build = ["setuptools-git", "wheel", "twine"]
-docs = ["sphinx", "zope.component", "sybil", "twisted", "mock", "django (<2)", "django"]
-test = ["pytest (>=3.6)", "pytest-cov", "pytest-django", "zope.component", "sybil", "twisted", "mock", "django (<2)", "django"]
+build = ["setuptools-git", "twine", "wheel"]
+docs = ["django", "django (<2)", "mock", "sphinx", "sybil", "twisted", "zope.component"]
+test = ["django", "django (<2)", "mock", "pytest (>=3.6)", "pytest-cov", "pytest-django", "sybil", "twisted", "zope.component"]
 
 [[package]]
 name = "toml"
@@ -845,7 +838,7 @@ click = ">=7.0"
 h11 = ">=0.8"
 
 [package.extras]
-standard = ["websockets (>=10.0)", "httptools (>=0.4.0)", "watchgod (>=0.6)", "python-dotenv (>=0.13)", "PyYAML (>=5.1)", "uvloop (>=0.14.0,!=0.15.0,!=0.15.1)", "colorama (>=0.4)"]
+standard = ["PyYAML (>=5.1)", "colorama (>=0.4)", "httptools (>=0.4.0)", "python-dotenv (>=0.13)", "uvloop (>=0.14.0,!=0.15.0,!=0.15.1)", "watchgod (>=0.6)", "websockets (>=10.0)"]
 
 [[package]]
 name = "virtualenv"
@@ -863,12 +856,12 @@ six = ">=1.9.0,<2"
 
 [package.extras]
 docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=21.3)"]
-testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)", "packaging (>=20.0)"]
+testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "packaging (>=20.0)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "3bbfe1a5284231e6a242da2d3d41a039d9364a5571e369de13d5b11821b25490"
+content-hash = "98655815e03d000bb61e9bce84af85d7ba2094439026991e8d3a1c61d4d287d2"
 
 [metadata.files]
 anyio = [
@@ -943,47 +936,56 @@ colorama = [
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 coverage = [
-    {file = "coverage-6.4.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f1d5aa2703e1dab4ae6cf416eb0095304f49d004c39e9db1d86f57924f43006b"},
-    {file = "coverage-6.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4ce1b258493cbf8aec43e9b50d89982346b98e9ffdfaae8ae5793bc112fb0068"},
-    {file = "coverage-6.4.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83c4e737f60c6936460c5be330d296dd5b48b3963f48634c53b3f7deb0f34ec4"},
-    {file = "coverage-6.4.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:84e65ef149028516c6d64461b95a8dbcfce95cfd5b9eb634320596173332ea84"},
-    {file = "coverage-6.4.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f69718750eaae75efe506406c490d6fc5a6161d047206cc63ce25527e8a3adad"},
-    {file = "coverage-6.4.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:e57816f8ffe46b1df8f12e1b348f06d164fd5219beba7d9433ba79608ef011cc"},
-    {file = "coverage-6.4.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:01c5615d13f3dd3aa8543afc069e5319cfa0c7d712f6e04b920431e5c564a749"},
-    {file = "coverage-6.4.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:75ab269400706fab15981fd4bd5080c56bd5cc07c3bccb86aab5e1d5a88dc8f4"},
-    {file = "coverage-6.4.1-cp310-cp310-win32.whl", hash = "sha256:a7f3049243783df2e6cc6deafc49ea123522b59f464831476d3d1448e30d72df"},
-    {file = "coverage-6.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:ee2ddcac99b2d2aec413e36d7a429ae9ebcadf912946b13ffa88e7d4c9b712d6"},
-    {file = "coverage-6.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fb73e0011b8793c053bfa85e53129ba5f0250fdc0392c1591fd35d915ec75c46"},
-    {file = "coverage-6.4.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:106c16dfe494de3193ec55cac9640dd039b66e196e4641fa8ac396181578b982"},
-    {file = "coverage-6.4.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:87f4f3df85aa39da00fd3ec4b5abeb7407e82b68c7c5ad181308b0e2526da5d4"},
-    {file = "coverage-6.4.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:961e2fb0680b4f5ad63234e0bf55dfb90d302740ae9c7ed0120677a94a1590cb"},
-    {file = "coverage-6.4.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:cec3a0f75c8f1031825e19cd86ee787e87cf03e4fd2865c79c057092e69e3a3b"},
-    {file = "coverage-6.4.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:129cd05ba6f0d08a766d942a9ed4b29283aff7b2cccf5b7ce279d50796860bb3"},
-    {file = "coverage-6.4.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:bf5601c33213d3cb19d17a796f8a14a9eaa5e87629a53979a5981e3e3ae166f6"},
-    {file = "coverage-6.4.1-cp37-cp37m-win32.whl", hash = "sha256:269eaa2c20a13a5bf17558d4dc91a8d078c4fa1872f25303dddcbba3a813085e"},
-    {file = "coverage-6.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:f02cbbf8119db68455b9d763f2f8737bb7db7e43720afa07d8eb1604e5c5ae28"},
-    {file = "coverage-6.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ffa9297c3a453fba4717d06df579af42ab9a28022444cae7fa605af4df612d54"},
-    {file = "coverage-6.4.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:145f296d00441ca703a659e8f3eb48ae39fb083baba2d7ce4482fb2723e050d9"},
-    {file = "coverage-6.4.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d67d44996140af8b84284e5e7d398e589574b376fb4de8ccd28d82ad8e3bea13"},
-    {file = "coverage-6.4.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2bd9a6fc18aab8d2e18f89b7ff91c0f34ff4d5e0ba0b33e989b3cd4194c81fd9"},
-    {file = "coverage-6.4.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3384f2a3652cef289e38100f2d037956194a837221edd520a7ee5b42d00cc605"},
-    {file = "coverage-6.4.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:9b3e07152b4563722be523e8cd0b209e0d1a373022cfbde395ebb6575bf6790d"},
-    {file = "coverage-6.4.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:1480ff858b4113db2718848d7b2d1b75bc79895a9c22e76a221b9d8d62496428"},
-    {file = "coverage-6.4.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:865d69ae811a392f4d06bde506d531f6a28a00af36f5c8649684a9e5e4a85c83"},
-    {file = "coverage-6.4.1-cp38-cp38-win32.whl", hash = "sha256:664a47ce62fe4bef9e2d2c430306e1428ecea207ffd68649e3b942fa8ea83b0b"},
-    {file = "coverage-6.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:26dff09fb0d82693ba9e6231248641d60ba606150d02ed45110f9ec26404ed1c"},
-    {file = "coverage-6.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d9c80df769f5ec05ad21ea34be7458d1dc51ff1fb4b2219e77fe24edf462d6df"},
-    {file = "coverage-6.4.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:39ee53946bf009788108b4dd2894bf1349b4e0ca18c2016ffa7d26ce46b8f10d"},
-    {file = "coverage-6.4.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f5b66caa62922531059bc5ac04f836860412f7f88d38a476eda0a6f11d4724f4"},
-    {file = "coverage-6.4.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fd180ed867e289964404051a958f7cccabdeed423f91a899829264bb7974d3d3"},
-    {file = "coverage-6.4.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:84631e81dd053e8a0d4967cedab6db94345f1c36107c71698f746cb2636c63e3"},
-    {file = "coverage-6.4.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:8c08da0bd238f2970230c2a0d28ff0e99961598cb2e810245d7fc5afcf1254e8"},
-    {file = "coverage-6.4.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:d42c549a8f41dc103a8004b9f0c433e2086add8a719da00e246e17cbe4056f72"},
-    {file = "coverage-6.4.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:309ce4a522ed5fca432af4ebe0f32b21d6d7ccbb0f5fcc99290e71feba67c264"},
-    {file = "coverage-6.4.1-cp39-cp39-win32.whl", hash = "sha256:fdb6f7bd51c2d1714cea40718f6149ad9be6a2ee7d93b19e9f00934c0f2a74d9"},
-    {file = "coverage-6.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:342d4aefd1c3e7f620a13f4fe563154d808b69cccef415415aece4c786665397"},
-    {file = "coverage-6.4.1-pp36.pp37.pp38-none-any.whl", hash = "sha256:4803e7ccf93230accb928f3a68f00ffa80a88213af98ed338a57ad021ef06815"},
-    {file = "coverage-6.4.1.tar.gz", hash = "sha256:4321f075095a096e70aff1d002030ee612b65a205a0a0f5b815280d5dc58100c"},
+    {file = "coverage-6.4.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e7b4da9bafad21ea45a714d3ea6f3e1679099e420c8741c74905b92ee9bfa7cc"},
+    {file = "coverage-6.4.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fde17bc42e0716c94bf19d92e4c9f5a00c5feb401f5bc01101fdf2a8b7cacf60"},
+    {file = "coverage-6.4.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdbb0d89923c80dbd435b9cf8bba0ff55585a3cdb28cbec65f376c041472c60d"},
+    {file = "coverage-6.4.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:67f9346aeebea54e845d29b487eb38ec95f2ecf3558a3cffb26ee3f0dcc3e760"},
+    {file = "coverage-6.4.4-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:42c499c14efd858b98c4e03595bf914089b98400d30789511577aa44607a1b74"},
+    {file = "coverage-6.4.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:c35cca192ba700979d20ac43024a82b9b32a60da2f983bec6c0f5b84aead635c"},
+    {file = "coverage-6.4.4-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:9cc4f107009bca5a81caef2fca843dbec4215c05e917a59dec0c8db5cff1d2aa"},
+    {file = "coverage-6.4.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:5f444627b3664b80d078c05fe6a850dd711beeb90d26731f11d492dcbadb6973"},
+    {file = "coverage-6.4.4-cp310-cp310-win32.whl", hash = "sha256:66e6df3ac4659a435677d8cd40e8eb1ac7219345d27c41145991ee9bf4b806a0"},
+    {file = "coverage-6.4.4-cp310-cp310-win_amd64.whl", hash = "sha256:35ef1f8d8a7a275aa7410d2f2c60fa6443f4a64fae9be671ec0696a68525b875"},
+    {file = "coverage-6.4.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c1328d0c2f194ffda30a45f11058c02410e679456276bfa0bbe0b0ee87225fac"},
+    {file = "coverage-6.4.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:61b993f3998ee384935ee423c3d40894e93277f12482f6e777642a0141f55782"},
+    {file = "coverage-6.4.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d5dd4b8e9cd0deb60e6fcc7b0647cbc1da6c33b9e786f9c79721fd303994832f"},
+    {file = "coverage-6.4.4-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7026f5afe0d1a933685d8f2169d7c2d2e624f6255fb584ca99ccca8c0e966fd7"},
+    {file = "coverage-6.4.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:9c7b9b498eb0c0d48b4c2abc0e10c2d78912203f972e0e63e3c9dc21f15abdaa"},
+    {file = "coverage-6.4.4-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:ee2b2fb6eb4ace35805f434e0f6409444e1466a47f620d1d5763a22600f0f892"},
+    {file = "coverage-6.4.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:ab066f5ab67059d1f1000b5e1aa8bbd75b6ed1fc0014559aea41a9eb66fc2ce0"},
+    {file = "coverage-6.4.4-cp311-cp311-win32.whl", hash = "sha256:9d6e1f3185cbfd3d91ac77ea065d85d5215d3dfa45b191d14ddfcd952fa53796"},
+    {file = "coverage-6.4.4-cp311-cp311-win_amd64.whl", hash = "sha256:e3d3c4cc38b2882f9a15bafd30aec079582b819bec1b8afdbde8f7797008108a"},
+    {file = "coverage-6.4.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a095aa0a996ea08b10580908e88fbaf81ecf798e923bbe64fb98d1807db3d68a"},
+    {file = "coverage-6.4.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef6f44409ab02e202b31a05dd6666797f9de2aa2b4b3534e9d450e42dea5e817"},
+    {file = "coverage-6.4.4-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4b7101938584d67e6f45f0015b60e24a95bf8dea19836b1709a80342e01b472f"},
+    {file = "coverage-6.4.4-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14a32ec68d721c3d714d9b105c7acf8e0f8a4f4734c811eda75ff3718570b5e3"},
+    {file = "coverage-6.4.4-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:6a864733b22d3081749450466ac80698fe39c91cb6849b2ef8752fd7482011f3"},
+    {file = "coverage-6.4.4-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:08002f9251f51afdcc5e3adf5d5d66bb490ae893d9e21359b085f0e03390a820"},
+    {file = "coverage-6.4.4-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:a3b2752de32c455f2521a51bd3ffb53c5b3ae92736afde67ce83477f5c1dd928"},
+    {file = "coverage-6.4.4-cp37-cp37m-win32.whl", hash = "sha256:f855b39e4f75abd0dfbcf74a82e84ae3fc260d523fcb3532786bcbbcb158322c"},
+    {file = "coverage-6.4.4-cp37-cp37m-win_amd64.whl", hash = "sha256:ee6ae6bbcac0786807295e9687169fba80cb0617852b2fa118a99667e8e6815d"},
+    {file = "coverage-6.4.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:564cd0f5b5470094df06fab676c6d77547abfdcb09b6c29c8a97c41ad03b103c"},
+    {file = "coverage-6.4.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:cbbb0e4cd8ddcd5ef47641cfac97d8473ab6b132dd9a46bacb18872828031685"},
+    {file = "coverage-6.4.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6113e4df2fa73b80f77663445be6d567913fb3b82a86ceb64e44ae0e4b695de1"},
+    {file = "coverage-6.4.4-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8d032bfc562a52318ae05047a6eb801ff31ccee172dc0d2504614e911d8fa83e"},
+    {file = "coverage-6.4.4-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e431e305a1f3126477abe9a184624a85308da8edf8486a863601d58419d26ffa"},
+    {file = "coverage-6.4.4-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:cf2afe83a53f77aec067033199797832617890e15bed42f4a1a93ea24794ae3e"},
+    {file = "coverage-6.4.4-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:783bc7c4ee524039ca13b6d9b4186a67f8e63d91342c713e88c1865a38d0892a"},
+    {file = "coverage-6.4.4-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:ff934ced84054b9018665ca3967fc48e1ac99e811f6cc99ea65978e1d384454b"},
+    {file = "coverage-6.4.4-cp38-cp38-win32.whl", hash = "sha256:e1fabd473566fce2cf18ea41171d92814e4ef1495e04471786cbc943b89a3781"},
+    {file = "coverage-6.4.4-cp38-cp38-win_amd64.whl", hash = "sha256:4179502f210ebed3ccfe2f78bf8e2d59e50b297b598b100d6c6e3341053066a2"},
+    {file = "coverage-6.4.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:98c0b9e9b572893cdb0a00e66cf961a238f8d870d4e1dc8e679eb8bdc2eb1b86"},
+    {file = "coverage-6.4.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:fc600f6ec19b273da1d85817eda339fb46ce9eef3e89f220055d8696e0a06908"},
+    {file = "coverage-6.4.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a98d6bf6d4ca5c07a600c7b4e0c5350cd483c85c736c522b786be90ea5bac4f"},
+    {file = "coverage-6.4.4-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:01778769097dbd705a24e221f42be885c544bb91251747a8a3efdec6eb4788f2"},
+    {file = "coverage-6.4.4-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dfa0b97eb904255e2ab24166071b27408f1f69c8fbda58e9c0972804851e0558"},
+    {file = "coverage-6.4.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:fcbe3d9a53e013f8ab88734d7e517eb2cd06b7e689bedf22c0eb68db5e4a0a19"},
+    {file = "coverage-6.4.4-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:15e38d853ee224e92ccc9a851457fb1e1f12d7a5df5ae44544ce7863691c7a0d"},
+    {file = "coverage-6.4.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:6913dddee2deff8ab2512639c5168c3e80b3ebb0f818fed22048ee46f735351a"},
+    {file = "coverage-6.4.4-cp39-cp39-win32.whl", hash = "sha256:354df19fefd03b9a13132fa6643527ef7905712109d9c1c1903f2133d3a4e145"},
+    {file = "coverage-6.4.4-cp39-cp39-win_amd64.whl", hash = "sha256:1238b08f3576201ebf41f7c20bf59baa0d05da941b123c6656e42cdb668e9827"},
+    {file = "coverage-6.4.4-pp36.pp37.pp38-none-any.whl", hash = "sha256:f67cf9f406cf0d2f08a3515ce2db5b82625a7257f88aad87904674def6ddaec1"},
+    {file = "coverage-6.4.4.tar.gz", hash = "sha256:e16c45b726acb780e1e6f88b286d3c10b3914ab03438f32117c4aa52d7f30d58"},
 ]
 distlib = [
     {file = "distlib-0.3.4-py2.py3-none-any.whl", hash = "sha256:6564fe0a8f51e734df6333d08b8b94d4ea8ee6b99b5ed50613f731fd4089f34b"},
@@ -1043,6 +1045,10 @@ flake8-requirements = [
 flake8-string-format = [
     {file = "flake8-string-format-0.3.0.tar.gz", hash = "sha256:65f3da786a1461ef77fca3780b314edb2853c377f2e35069723348c8917deaa2"},
     {file = "flake8_string_format-0.3.0-py2.py3-none-any.whl", hash = "sha256:812ff431f10576a74c89be4e85b8e075a705be39bc40c4b4278b5b13e2afa9af"},
+]
+fundom = [
+    {file = "fundom-0.1.0-py3-none-any.whl", hash = "sha256:163029ff76c1b1fe35da4bc4c2995c31355c7f42837935f44f7dedf729e21841"},
+    {file = "fundom-0.1.0.tar.gz", hash = "sha256:109855abf1e0f7bd378d26a3c3272b0f4a47db5bebe0e9f4d7d0091150d09683"},
 ]
 gitdb = [
     {file = "gitdb-4.0.9-py3-none-any.whl", hash = "sha256:8033ad4e853066ba6ca92050b9df2f89301b8fc8bf7e9324d412a63f8bf1a8fd"},
@@ -1215,7 +1221,6 @@ pyflakes = [
     {file = "pyflakes-2.4.0-py2.py3-none-any.whl", hash = "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"},
     {file = "pyflakes-2.4.0.tar.gz", hash = "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c"},
 ]
-pymon = []
 pyparsing = [
     {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
     {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ orjson = "^3.6.7"
 pydantic = "^1.9.0"
 toolz = "^0.11.2"
 typing-extensions = "^4.1.1"
-pymon = {git = "https://github.com/katunilya/pymon.git", rev = "v0.0.5"}
+fundom = "^0.1.0"
 
 [tool.poetry.dev-dependencies]
 black = "^22.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ orjson = "^3.6.7"
 pydantic = "^1.9.0"
 toolz = "^0.11.2"
 typing-extensions = "^4.1.1"
-pymon = {git = "https://github.com/katunilya/pymon.git", tag = "v0.0.3"}
+pymon = {git = "https://github.com/katunilya/pymon.git", rev = "v0.0.5"}
 
 [tool.poetry.dev-dependencies]
 black = "^22.1.0"

--- a/tests/http/test_request_headers.py
+++ b/tests/http/test_request_headers.py
@@ -16,7 +16,7 @@ from moona.http.request_headers import has_header, matches_header
         ("Random-Header", b"", False),
     ],
 )
-async def test_has_header_1(ctx: HTTPContext, s_name, b_name, result):
+async def test_has_header(ctx: HTTPContext, s_name, b_name, result):
     ctx.request_headers[b_name] = b""
     _ctx = await has_header(s_name)(end, ctx)
     assert (_ctx is not None) == result


### PR DESCRIPTION
- Update `pymon` dependency (#60)
- Remove `pymon`; Add `fundom`
- Rewrite code for `fundom` usage
- Update docs

Closes #60
